### PR TITLE
feat: add HTTPS support with optional self-signed cert generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "imapflow": "^1.0.0",
         "mailparser": "^3.0.0",
         "pino": "^9.0.0",
+        "selfsigned": "^2.4.1",
         "zod": "^3.0.0"
       },
       "devDependencies": {
@@ -1363,10 +1364,18 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -6441,6 +6450,15 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
@@ -8049,6 +8067,19 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -8870,7 +8901,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "dev":   "tsx watch src/index.ts",
+    "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
-    "lint":  "eslint 'src/**/*.ts'",
-    "test":  "echo 'No tests yet — add vitest and update this script' && exit 0",
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "echo 'No tests yet — add vitest and update this script' && exit 0",
     "inspector": "npm run build && bash scripts/run_inspector.sh"
   },
   "volta": {
@@ -26,17 +26,18 @@
     "imapflow": "^1.0.0",
     "mailparser": "^3.0.0",
     "pino": "^9.0.0",
+    "selfsigned": "^2.4.1",
     "zod": "^3.0.0"
   },
   "devDependencies": {
+    "@release-it/keep-a-changelog": "^5.0.0",
     "@types/mailparser": "^3.0.0",
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
-    "tsx": "^4.0.0",
-    "typescript": "^6.0.0",
     "release-it": "^17.0.0",
-    "@release-it/keep-a-changelog": "^5.0.0"
+    "tsx": "^4.0.0",
+    "typescript": "^6.0.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { Command } from 'commander';
-import type { AppConfig } from './types/index.js';
+import selfsigned from 'selfsigned';
+import type { AppConfig, McpHttpTlsConfig } from './types/index.js';
 
 function requireValue(
   cliValue: string | undefined,
@@ -34,6 +36,30 @@ function intValue(
   return parsed;
 }
 
+function buildTlsConfig(
+  httpsEnabled: boolean,
+  certPath:     string | undefined,
+  keyPath:      string | undefined,
+): McpHttpTlsConfig | undefined {
+  if (!httpsEnabled) return undefined;
+
+  if (certPath && keyPath) {
+    return {
+      cert: readFileSync(certPath, 'utf8'),
+      key:  readFileSync(keyPath,  'utf8'),
+    };
+  }
+
+  if (certPath || keyPath) {
+    throw new Error('Both --https-cert and --https-key must be provided together');
+  }
+
+  // Auto-generate a self-signed certificate
+  const attrs = [{ name: 'commonName', value: 'proton-bridge-mcp' }];
+  const generated = selfsigned.generate(attrs, { days: 365, keySize: 2048 });
+  return { cert: generated.cert, key: generated.private };
+}
+
 export function loadConfig(argv: string[]): AppConfig {
   const program = new Command();
 
@@ -53,6 +79,9 @@ export function loadConfig(argv: string[]): AppConfig {
     .option('--audit-log-path <path>',        'Audit log file path (required)')
     .option('--log-path <path>',              'Application log file path (stderr if omitted)')
     .option('--log-level <level>',            'Log level: trace|debug|info|warn|error')
+    .option('--https',                        'Enable HTTPS (env: PROTONMAIL_HTTPS)')
+    .option('--https-cert <path>',            'Path to PEM certificate file (env: PROTONMAIL_HTTPS_CERT_PATH)')
+    .option('--https-key <path>',             'Path to PEM private key file (env: PROTONMAIL_HTTPS_KEY_PATH)')
     .option('--verify',                       'Verify IMAP connectivity then exit')
     .allowUnknownOption(false)
     .parse(argv);
@@ -71,8 +100,17 @@ export function loadConfig(argv: string[]): AppConfig {
     auditLogPath?:   string;
     logPath?:        string;
     logLevel?:       string;
+    https?:          boolean;
+    httpsCert?:      string;
+    httpsKey?:       string;
     verify?:         boolean;
   }>();
+
+  const httpsTls = buildTlsConfig(
+    opts.https ?? (process.env['PROTONMAIL_HTTPS'] === 'true'),
+    optionalValue(opts.httpsCert, 'PROTONMAIL_HTTPS_CERT_PATH'),
+    optionalValue(opts.httpsKey,  'PROTONMAIL_HTTPS_KEY_PATH'),
+  );
 
   return {
     bridge: {
@@ -91,6 +129,7 @@ export function loadConfig(argv: string[]): AppConfig {
       port:      intValue(opts.mcpPort, 'PROTONMAIL_MCP_PORT', 3000),
       basePath:  opts.mcpBasePath ?? process.env['PROTONMAIL_MCP_BASE_PATH']  ?? '/mcp',
       authToken: requireValue(opts.mcpAuthToken, 'PROTONMAIL_MCP_AUTH_TOKEN', 'mcp-auth-token'),
+      ...(httpsTls ? { tls: httpsTls } : {}),
     },
     log: (() => {
       const logPath = optionalValue(opts.logPath, 'PROTONMAIL_LOG_PATH') || undefined;

--- a/src/http.ts
+++ b/src/http.ts
@@ -22,7 +22,10 @@ export async function createHttpApp(
   config: McpHttpConfig,
   logger: AppLogger,
 ): Promise<FastifyInstance> {
-  const app = Fastify({ loggerInstance: logger as unknown as FastifyBaseLogger });
+  const app = Fastify({
+    ...(config.tls ? { https: config.tls } : {}),
+    loggerInstance: logger as unknown as FastifyBaseLogger,
+  });
 
   const sessions = new Map<string, Session>();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,8 +36,9 @@ async function main(): Promise<void> {
 
   await app.listen({ host: config.http.host, port: config.http.port });
 
+  const protocol = config.http.tls ? 'https' : 'http';
   logger.info(
-    { host: config.http.host, port: config.http.port, basePath: config.http.basePath },
+    { host: config.http.host, port: config.http.port, basePath: config.http.basePath, protocol },
     'MCP server listening',
   );
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,11 +13,17 @@ export interface ConnectionPoolConfig {
   max: number;
 }
 
+export interface McpHttpTlsConfig {
+  cert: string;  // PEM certificate
+  key:  string;  // PEM private key
+}
+
 export interface McpHttpConfig {
   host:      string;
   port:      number;
   basePath:  string;
   authToken: string;
+  tls?:      McpHttpTlsConfig;  // present = HTTPS; absent = plain HTTP
 }
 
 export interface LogConfig {


### PR DESCRIPTION
Closes #6

## Summary
- New `--https` flag (env: `PROTONMAIL_HTTPS=true`) enables TLS on the MCP HTTP interface
- Optional `--https-cert <path>` / `--https-key <path>` flags (env: `PROTONMAIL_HTTPS_CERT_PATH` / `PROTONMAIL_HTTPS_KEY_PATH`) accept BYO PEM files
- When `--https` is set but no cert/key paths are provided, a self-signed certificate is auto-generated via the `selfsigned` package (valid 365 days) — no manual setup required
- Startup log now includes `protocol: "https"` or `"http"`

## Test plan
- [ ] Plain HTTP still works without `--https` (no regression)
- [ ] `--https` alone starts the server over TLS with an auto-generated cert: `curl -k -H "Authorization: Bearer <token>" -X POST https://127.0.0.1:3000/mcp` → 400/200, not a connection error
- [ ] `--https` without a valid token returns 401 over TLS
- [ ] `--https-cert ./cert.pem --https-key ./key.pem` uses the provided cert (generate with `mkcert` or `openssl`)
- [ ] Providing only one of `--https-cert` / `--https-key` throws an error at startup
- [ ] `npm run lint` and `npm run build` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)