### PR TITLE
docs: comprehensive README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,580 @@
-# proton-bridge-mcp
-Yet another ProtonMail MCP bridge
+<p align="center">
+  <img src="assets/logo.svg" alt="proton-bridge-mcp" width="480" />
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/MCP-Server-blue?style=flat-square" alt="MCP Server" />
+  <img src="https://img.shields.io/badge/TypeScript-6-3178c6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript 6" />
+  <img src="https://img.shields.io/badge/Node.js-%E2%89%A525.9-339933?style=flat-square&logo=node.js&logoColor=white" alt="Node.js >= 25.9" />
+  <img src="https://img.shields.io/badge/License-MIT-green?style=flat-square" alt="MIT License" />
+  <img src="https://img.shields.io/github/actions/workflow/status/grover/proton-bridge-mcp/ci.yml?branch=main&style=flat-square&label=CI" alt="CI Status" />
+</p>
+
+<h1 align="center">proton-bridge-mcp</h1>
+
+<p align="center">
+  <strong>Give your AI agent access to ProtonMail.</strong>
+</p>
+
+An [MCP](https://modelcontextprotocol.io/) server that bridges ProtonMail to AI agents via the local [Proton Bridge](https://proton.me/mail/bridge) IMAP daemon. Read, search, organize, and manage your encrypted email — all through the Model Context Protocol.
+
+---
+
+## Table of Contents
+
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Other Usage](#other-usage)
+- [Authentication](#authentication)
+- [Configuration Reference](#configuration-reference)
+- [MCP Tools](#mcp-tools)
+- [Claude Desktop Manual Configuration](#claude-desktop-manual-configuration)
+- [Security](#security)
+- [Troubleshooting](#troubleshooting)
+- [Development](#development)
+- [Architecture](#architecture)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
+
+---
+
+## Features
+
+- **11 MCP tools** for reading, searching, and organizing email
+- **Three transport modes** — STDIO, HTTP, and HTTPS
+- **IMAP connection pooling** with configurable min/max connections and idle drain timers
+- **Batch operations** with input-order stability and per-item error reporting
+- **Audit logging** of all mutating operations (JSONL)
+- **Claude Desktop packaging** via `.mcpb` bundles
+- **Zero external services** — connects directly to your local Proton Bridge
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| **Node.js >= 25.9** | See `.nvmrc` for exact version |
+| **Proton Bridge** | Running locally with IMAP enabled (default port `1143`) |
+| **Bridge mailbox password** | Found in Proton Bridge app under **Account > Mailbox password** |
+
+> **Important:** The bridge mailbox password is _not_ your ProtonMail login password. Proton Bridge generates a separate password specifically for IMAP access.
+
+## Quick Start
+
+The fastest way to get started is to install the pre-built `.mcpb` package in Claude Desktop.
+
+### 1. Install Proton Mail Bridge
+
+Download and install [Proton Mail Bridge](https://proton.me/mail/bridge) from Proton. Sign in with your ProtonMail account and wait for the initial sync to complete.
+
+### 2. Note Your Bridge Mailbox Password
+
+In the Proton Bridge app, click on your account and copy the **Mailbox password**. This is a Bridge-generated password — it is **not** your ProtonMail login password.
+
+### 3. Install the MCPB Package
+
+Download `proton-bridge-mcp.mcpb` from the [latest GitHub release](https://github.com/grover/proton-bridge-mcp/releases/latest) and open it with Claude Desktop. The installer will prompt you to configure two required fields:
+
+| Field | What to enter |
+|---|---|
+| **ProtonMail Address** | Your email address (e.g. `you@protonmail.com`) |
+| **Bridge Mailbox Password** | The password you copied from Proton Bridge in step 2 |
+
+All other settings (host, port, pool size, log level) have sensible defaults and can be left as-is.
+
+### 4. Verify It Works
+
+Once installed, ask Claude to check your email. The server runs in **STDIO mode** — Claude Desktop launches it as a subprocess, so there's no network listener and no auth token to manage. Behind the scenes, Claude will use the `verify_connectivity` tool to confirm the connection to Proton Bridge is healthy.
+
+> **That's it.** You can now ask Claude to read, search, and organize your ProtonMail.
+
+---
+
+## Other Usage
+
+Beyond the MCPB quick-start, you can run the server directly from a local build. It supports three transport modes.
+
+### STDIO (Default)
+
+The simplest mode — communicates over stdin/stdout. This is the default when no transport flag is provided and is ideal for **Claude Desktop** and other MCP clients that launch the server as a subprocess.
+
+```bash
+npm run build
+
+node dist/index.js \
+  --bridge-username your@protonmail.com \
+  --bridge-password your-bridge-password
+```
+
+No auth token is needed — the process boundary _is_ the security boundary.
+
+### HTTP
+
+Runs a Fastify HTTP server with Bearer token authentication. Use this when the MCP client connects over the network or when you want to share one server across multiple sessions.
+
+```bash
+node dist/index.js --http \
+  --bridge-username your@protonmail.com \
+  --bridge-password your-bridge-password \
+  --mcp-auth-token your-secret-token
+```
+
+The server listens on `127.0.0.1:3000/mcp` by default. Each HTTP session gets its own `McpServer` instance, while the IMAP pool is shared.
+
+### HTTPS
+
+Same as HTTP but with TLS. If you don't provide cert/key paths, the server **auto-generates a self-signed certificate** at startup.
+
+```bash
+# Auto-generated self-signed cert
+node dist/index.js --https \
+  --bridge-username your@protonmail.com \
+  --bridge-password your-bridge-password \
+  --mcp-auth-token your-secret-token
+
+# Custom certificate
+node dist/index.js --https \
+  --bridge-username your@protonmail.com \
+  --bridge-password your-bridge-password \
+  --mcp-auth-token your-secret-token \
+  --https-cert /path/to/cert.pem \
+  --https-key /path/to/key.pem
+```
+
+---
+
+## Authentication
+
+> **Using the MCPB package?** The installer handles credential configuration for you — just enter your ProtonMail address and Bridge mailbox password during setup. The details below are for manual or advanced configurations.
+
+### Bridge Authentication (IMAP)
+
+All transport modes require bridge credentials to connect to Proton Bridge's IMAP server:
+
+| Parameter | CLI Flag | Environment Variable |
+|---|---|---|
+| Username | `--bridge-username` | `PROTONMAIL_BRIDGE_USERNAME` |
+| Password | `--bridge-password` | `PROTONMAIL_BRIDGE_PASSWORD` |
+
+These are always required. The password is the bridge-generated mailbox password, not your ProtonMail account password. The MCPB manifest ([`manifest.json`](manifest.json)) configures these automatically from the values you enter during installation.
+
+### MCP Authentication (HTTP/HTTPS only)
+
+HTTP and HTTPS modes require a Bearer token for client authentication. This is **not needed for STDIO mode** (including MCPB installations), since the process boundary provides isolation.
+
+| Parameter | CLI Flag | Environment Variable |
+|---|---|---|
+| Auth Token | `--mcp-auth-token` | `PROTONMAIL_MCP_AUTH_TOKEN` |
+
+Clients must include the token in every request:
+
+```
+Authorization: Bearer your-secret-token
+```
+
+### OAuth 2.0 (Planned)
+
+OAuth 2.0 support is planned for a future milestone but is not yet implemented. See [issue #7](https://github.com/grover/proton-bridge-mcp/issues/7) for tracking.
+
+---
+
+## Configuration Reference
+
+Configuration follows the precedence: **CLI flags > Environment variables > Defaults**.
+
+All environment variables use the `PROTONMAIL_` prefix. You can set them in a `.env` file (see [`.env.example`](.env.example)).
+
+### Bridge Connection
+
+| CLI Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--bridge-host` | `PROTONMAIL_BRIDGE_HOST` | `127.0.0.1` | Proton Bridge IMAP host |
+| `--bridge-imap-port` | `PROTONMAIL_BRIDGE_IMAP_PORT` | `1143` | Proton Bridge IMAP port |
+| `--bridge-username` | `PROTONMAIL_BRIDGE_USERNAME` | _(required)_ | ProtonMail email address |
+| `--bridge-password` | `PROTONMAIL_BRIDGE_PASSWORD` | _(required)_ | Bridge mailbox password |
+
+### Connection Pool
+
+| CLI Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--pool-min` | `PROTONMAIL_CONNECTION_POOL_MIN` | `1` | Min idle connections |
+| `--pool-max` | `PROTONMAIL_CONNECTION_POOL_MAX` | `5` | Max concurrent connections |
+| `--pool-idle-drain-secs` | `PROTONMAIL_CONNECTION_POOL_IDLE_DRAIN_SECS` | `30` | Drain to min after N idle seconds |
+| `--pool-idle-timeout-secs` | `PROTONMAIL_CONNECTION_POOL_IDLE_TIMEOUT_SECS` | `300` | Empty pool entirely after N idle seconds (0 = disabled) |
+
+### HTTP/HTTPS Server
+
+| CLI Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--http` | — | — | Enable HTTP transport |
+| `--https` | — | — | Enable HTTPS transport |
+| `--mcp-host` | `PROTONMAIL_MCP_HOST` | `127.0.0.1` | Server listen address |
+| `--mcp-port` | `PROTONMAIL_MCP_PORT` | `3000` | Server listen port |
+| `--mcp-base-path` | `PROTONMAIL_MCP_BASE_PATH` | `/mcp` | MCP endpoint path |
+| `--mcp-auth-token` | `PROTONMAIL_MCP_AUTH_TOKEN` | _(required)_ | Bearer auth token |
+| `--https-cert` | `PROTONMAIL_HTTPS_CERT_PATH` | _(auto-generated)_ | TLS certificate path |
+| `--https-key` | `PROTONMAIL_HTTPS_KEY_PATH` | _(auto-generated)_ | TLS private key path |
+
+### Logging
+
+| CLI Flag | Env Var | Default | Description |
+|---|---|---|---|
+| `--log-path` | `PROTONMAIL_LOG_PATH` | _(stderr)_ | Application log file path |
+| `--log-level` | `PROTONMAIL_LOG_LEVEL` | `info` | Log level: `trace` `debug` `info` `warn` `error` |
+| `--audit-log-path` | `PROTONMAIL_AUDIT_LOG_PATH` | `~/.proton-bridge-mcp/audit.jsonl` | Audit log file path |
+
+### Utility
+
+| CLI Flag | Description |
+|---|---|
+| `--verify` | Test IMAP connectivity and exit (status 0 = success, 1 = failure) |
+
+---
+
+## MCP Tools
+
+The server exposes 11 tools that MCP clients can call. Each tool is annotated with `readOnlyHint` or `destructiveHint` so clients can present appropriate confirmation prompts.
+
+For **full documentation** — including input schemas, return types, and example JSON — see the **[Tools Reference](docs/tools/README.md)**.
+
+| Tool | Flags | Description |
+|---|---|---|
+| `list_folders` | read-only | List all IMAP mailboxes with special-use flags (Inbox, Sent, Drafts, etc.) |
+| `list_mailbox` | read-only | Browse emails in a mailbox, newest first, with pagination |
+| `fetch_summaries` | read-only | Fetch envelope data (from, to, subject, date, flags) for known email IDs |
+| `fetch_message` | read-only | Fetch full message body (text/HTML) and attachment metadata |
+| `fetch_attachment` | read-only | Download a single attachment by part ID (base64-encoded) |
+| `search_mailbox` | read-only | Full-text IMAP search within a mailbox, with pagination |
+| `move_emails` | destructive | Move a batch of emails to another mailbox |
+| `mark_read` | mutating | Add the `\Seen` flag to a batch of emails |
+| `mark_unread` | mutating | Remove the `\Seen` flag from a batch of emails |
+| `verify_connectivity` | read-only | Test connection to Proton Bridge and report latency |
+| `drain_connections` | read-only | Close all pooled connections (useful after a Bridge restart) |
+
+All batch operations preserve input order in results and report per-item success/failure.
+
+---
+
+## Claude Desktop Manual Configuration
+
+If you prefer not to use the MCPB package (see [Quick Start](#quick-start)), you can configure Claude Desktop manually by editing its config file.
+
+**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "proton-bridge-mcp": {
+      "command": "node",
+      "args": [
+        "/path/to/proton-bridge-mcp/dist/index.js",
+        "--bridge-username", "your@protonmail.com",
+        "--bridge-password", "your-bridge-password"
+      ]
+    }
+  }
+}
+```
+
+This uses STDIO mode. For HTTP/HTTPS usage with Claude Desktop, see [Other Usage](#other-usage).
+
+---
+
+## Security
+
+This server handles email credentials and provides access to your private mailbox. Take these precautions seriously.
+
+### Choose STDIO When Possible
+
+**STDIO mode is the recommended transport for local use**, even if your MCP client supports HTTP. In STDIO mode, credentials never leave the process boundary — there is no network listener, no auth token to leak, and no attack surface beyond the process itself.
+
+Use HTTP or HTTPS only when you genuinely need network-based access (e.g., a remote MCP client, or multiple clients sharing one server).
+
+### Bearer Token Security (HTTP/HTTPS)
+
+When running in HTTP or HTTPS mode:
+
+- **Generate a strong, random token** — at least 32 characters. Use `openssl rand -hex 32` or a password manager.
+- **Never commit tokens to version control.** Use environment variables or a `.env` file (which is `.gitignore`'d).
+- **HTTPS is strongly preferred over HTTP.** Plain HTTP transmits the Bearer token in cleartext on every request. Even on `localhost`, other processes or browser extensions could potentially intercept it. HTTPS mode auto-generates a self-signed certificate if you don't provide one — there's no reason not to use it.
+- **Bind to `127.0.0.1`, not `0.0.0.0`.** The default listen address is `127.0.0.1`, which restricts access to the local machine. Changing this to `0.0.0.0` exposes the server to your entire network.
+
+### OAuth 2.0 (Not Yet Implemented)
+
+OAuth 2.0 support is tracked in [issue #7](https://github.com/grover/proton-bridge-mcp/issues/7) but is **not yet implemented**. Until then, Bearer token authentication is the only option for HTTP/HTTPS modes. Do not assume OAuth is available.
+
+### Environment Variables and Secrets
+
+Credentials can be passed via CLI flags or environment variables. Be aware of the tradeoffs:
+
+| Method | Pros | Cons |
+|---|---|---|
+| CLI flags | Explicit, easy to audit | Visible in `ps` output and shell history |
+| Environment variables | Not in `ps` output | Visible to child processes; may leak in crash dumps |
+| `.env` file | Convenient for development | Must be excluded from version control |
+
+For production use, consider a secrets manager or restricting file permissions on your `.env` file (`chmod 600 .env`).
+
+### Firewall Recommendations
+
+Proton Bridge exposes IMAP (default `1143`) and SMTP (default `1025`) on localhost. While these are bound to `127.0.0.1` by default, it's good practice to **firewall these ports** to prevent any unsolicited access:
+
+**macOS (pf):**
+```bash
+# Block external access to Bridge ports (add to /etc/pf.conf)
+block in on ! lo0 proto tcp to any port { 1143, 1025 }
+```
+
+**Linux (ufw):**
+```bash
+sudo ufw deny in on eth0 to any port 1143
+sudo ufw deny in on eth0 to any port 1025
+```
+
+This ensures that even if Bridge's listen address is misconfigured, no external machine can reach it.
+
+### Audit Logging
+
+All mutating operations (move, mark read/unread) are logged to a JSONL audit file at `~/.proton-bridge-mcp/audit.jsonl` by default. Review this log periodically to verify that only expected operations are occurring:
+
+```bash
+tail -f ~/.proton-bridge-mcp/audit.jsonl | jq .
+```
+
+### What This Server Does NOT Do
+
+- It does **not** store or cache your emails — all data is fetched live from Proton Bridge
+- It does **not** send emails (no SMTP support yet)
+- It does **not** phone home or contact any external service
+- It does **not** modify Bridge settings or your ProtonMail account
+
+---
+
+## Troubleshooting
+
+### Connection Refused on Port 1143
+
+**Cause:** Proton Bridge is not running or IMAP is disabled.
+
+**Fix:**
+1. Launch Proton Mail Bridge and wait for it to fully start
+2. Check that the status indicator shows green / "Connected"
+3. Verify IMAP is enabled in Bridge settings (click your account > check IMAP toggle)
+4. Ask your MCP client to call the `verify_connectivity` tool — it will report whether the connection succeeds and the round-trip latency
+
+### Authentication Failed
+
+**Cause:** Wrong password or account needs re-authentication in Bridge.
+
+**Fix:**
+1. Open Proton Bridge and click on your account
+2. If prompted, sign in again
+3. Copy the **Mailbox password** (not your ProtonMail login password!)
+4. Update your `.env` or CLI flags with the new password
+
+### Stale or Missing Emails
+
+**Cause:** Proton Bridge's local sync database may be out of date or corrupted.
+
+**Fix:**
+1. Open Proton Bridge, click your account, and use the **Repair** function
+2. Wait for the resync to complete
+3. Use the `drain_connections` MCP tool to force fresh IMAP connections
+
+See the [Bridge Repair Guide](docs/bridge-repair/README.md) for detailed step-by-step instructions.
+
+### Bridge Crashes or Freezes
+
+Proton Bridge can occasionally become unresponsive, especially after system sleep/wake cycles or network changes.
+
+**Fix:**
+1. Force-quit Bridge (Activity Monitor on macOS, Task Manager on Windows)
+2. Restart Bridge
+3. If crashes persist, try the [full reset procedure](docs/bridge-repair/README.md#full-reset-nuclear-option)
+
+### "Too Many Connections" Errors
+
+**Cause:** The connection pool max is set higher than Bridge can handle, or stale connections aren't being released.
+
+**Fix:**
+1. Lower `--pool-max` (try `3` instead of `5`)
+2. Use the `drain_connections` tool to flush the pool
+3. Restart the MCP server
+
+### Self-Signed Certificate Warnings
+
+When using `--https` without providing a certificate, the server generates a self-signed cert. MCP clients may warn about this.
+
+**Fix:** Either provide a proper certificate via `--https-cert` and `--https-key`, or configure your client to trust the self-signed cert. For local development, self-signed is fine.
+
+### Debugging Tips
+
+- **Increase log verbosity:** `--log-level debug` (or `trace` for maximum detail)
+- **Watch the audit log:** `tail -f ~/.proton-bridge-mcp/audit.jsonl | jq .`
+- **Test with MCP Inspector:** `npm run inspector` launches an interactive web UI
+- **Check Bridge logs:** Proton Bridge has its own logs — find them via Bridge Settings > Logs
+
+---
+
+## Development
+
+### Setup
+
+```bash
+git clone https://github.com/grover/proton-bridge-mcp.git
+cd proton-bridge-mcp
+nvm use           # or volta, mise, asdf — picks up .nvmrc / volta pin
+npm install
+cp .env.example .env
+# Fill in your bridge credentials in .env
+```
+
+### Scripts
+
+| Script | Description |
+|---|---|
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm run dev` | Watch mode with tsx (auto-restart on changes) |
+| `npm run lint` | ESLint with type-aware parsing |
+| `npm test` | Run tests (vitest, when added) |
+| `npm run inspector` | Build and launch MCP Inspector |
+| `npm run package` | Build and create `.mcpb` bundle |
+
+### Debugging with MCP Inspector
+
+The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) provides a web UI for testing tools interactively:
+
+```bash
+# HTTP mode
+node dist/index.js --http \
+  --bridge-username x --bridge-password y \
+  --mcp-auth-token my-token &
+
+npx @modelcontextprotocol/inspector http://127.0.0.1:3000/mcp
+# Set the Authorization header to: Bearer my-token
+```
+
+### Watching the Audit Log
+
+```bash
+tail -f ~/.proton-bridge-mcp/audit.jsonl | jq .
+```
+
+### Project Structure
+
+```
+src/
+  index.ts          Entry point — CLI parsing and transport dispatch
+  config.ts         CLI flags, env vars, and config validation
+  server.ts         MCP tool registration and handler logic
+  stdio.ts          STDIO transport setup
+  logger.ts         Pino app logger (stderr or file)
+  bridge/
+    imap.ts         ImapClient — all IMAP operations
+    pool.ts         ImapConnectionPool with version-based drain
+    audit.ts        JSONL audit logger for mutating operations
+    decorators.ts   @Audited decorator
+  types/
+    config.ts       Config type definitions
+    email.ts        Email, folder, and attachment types
+  http/
+    app.ts          Fastify HTTP/HTTPS app factory
+```
+
+### Code Conventions
+
+- **ESM only** — all local imports must use `.js` extensions (`import { Foo } from './foo.js'`)
+- **TypeScript 6** with `exactOptionalPropertyTypes` and strict mode
+- **`@Audited` decorator** on every public `ImapClient` method
+- **Batch-first** — all operations accept arrays and preserve input order
+- **Config precedence** — CLI flags > env vars > defaults
+
+---
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for full design detail. The high-level layer stack:
+
+```
+MCP Client (Claude, Inspector, etc.)
+       |
+  [ Transport Layer ]
+  STDIO | HTTP | HTTPS (Fastify + Bearer auth)
+       |
+  [ MCP Server ]
+  Tool registration, input validation (Zod)
+       |
+  [ ImapClient ]
+  @Audited methods, batch grouping by mailbox
+       |
+  [ ImapConnectionPool ]
+  Version-based drain, idle timers, min/max sizing
+       |
+  Proton Bridge IMAP (127.0.0.1:1143)
+```
+
+---
+
+## Contributing
+
+Contributions are welcome! Here's how to get started:
+
+1. **Fork and clone** the repository
+2. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feat/your-feature
+   ```
+3. **Make your changes** — follow the code conventions above
+4. **Run the pre-commit checklist** before every commit:
+   ```bash
+   npm install        # ensure lockfile is in sync
+   npm run lint       # must pass with zero errors
+   npm run build      # must compile clean
+   npm ci             # verify lockfile consistency
+   ```
+5. **Push and open a PR** against `main`
+
+### CI & Review
+
+Every PR runs three parallel checks: **Lint**, **Build**, and **Test**. All three must pass before merging.
+
+PRs are reviewed and merged by the maintainer. This is a side project — response times may vary, so please be patient. Quality contributions are always appreciated.
+
+### Releases
+
+Releases are managed with [release-it](https://github.com/release-it/release-it). Maintainers run `npx release-it` locally, which bumps the version, updates the changelog, and pushes a tag. CI then creates the GitHub Release automatically.
+
+---
+
+## Acknowledgements
+
+### Built With
+
+- **[Proton Mail Bridge](https://proton.me/mail/bridge)** — the local IMAP/SMTP gateway that makes this project possible. Proton Bridge decrypts your end-to-end encrypted ProtonMail locally so standard mail clients (and this MCP server) can access it.
+- **[Model Context Protocol SDK](https://github.com/modelcontextprotocol/typescript-sdk)** — the TypeScript SDK for building MCP servers
+- **[ImapFlow](https://github.com/postalsys/imapflow)** — modern, promise-based IMAP client for Node.js
+- **[Fastify](https://fastify.dev/)** — high-performance HTTP framework powering the HTTP/HTTPS transport
+- **[Pino](https://getpino.io/)** — super-fast JSON logger for Node.js
+- **[Commander.js](https://github.com/tj/commander.js)** — CLI argument parsing
+- **[Zod](https://zod.dev/)** — TypeScript-first schema validation for MCP tool inputs
+- **[mailparser](https://nodemailer.com/extras/mailparser/)** — MIME message parsing for email bodies and attachments
+- **[TypeScript](https://www.typescriptlang.org/)** 6 — the language this project is written in
+
+### Created With
+
+- **[Claude Code](https://claude.ai/claude-code)** by [Anthropic](https://www.anthropic.com/) — AI-assisted development
+- **[Claude](https://claude.ai/)** by [Anthropic](https://www.anthropic.com/) — design, architecture, and code generation
+- **[Visual Studio Code](https://code.visualstudio.com/)** — code editor
+- **[GitHub](https://github.com/)** — source control, CI/CD, and collaboration
+
+---
+
+## License
+
+[MIT](LICENSE) &copy; 2026 Michael Fröhlich and [Claude](https://claude.ai/) by [Anthropic](https://www.anthropic.com/)
+
+---
+
+<sub>Proton, Proton Mail, and Proton Mail Bridge are trademarks of [Proton AG](https://proton.me/). This project is not affiliated with, endorsed by, or sponsored by Proton AG. It is an independent open-source tool that interfaces with the locally installed Proton Mail Bridge application.</sub>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 220" fill="none">
+  <defs>
+    <!-- Proton Mail icon gradients (from official asset) -->
+    <linearGradient id="pm0" x1="13.509" y1="24.7672" x2="1.43523" y2="-17.1751" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#E3D9FF"/>
+      <stop offset="1" stop-color="#7341FF"/>
+    </linearGradient>
+    <radialGradient id="pm1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(30.7227 11.8138) scale(35.9848 33.9185)">
+      <stop offset="0.5561" stop-color="#6D4AFF"/>
+      <stop offset="0.9944" stop-color="#AA8EFF"/>
+    </radialGradient>
+    <linearGradient id="pm2" x1="47.6423" y1="50.957" x2="19.8702" y2="-8.95322" gradientUnits="userSpaceOnUse">
+      <stop offset="0.271" stop-color="#E3D9FF"/>
+      <stop offset="1" stop-color="#7341FF"/>
+    </linearGradient>
+
+    <!-- MCP icon using Proton color palette -->
+    <linearGradient id="mcpGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6D4AFF"/>
+      <stop offset="100%" stop-color="#AA8EFF"/>
+    </linearGradient>
+
+    <!-- Bridge connector gradient -->
+    <linearGradient id="bridgeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6D4AFF"/>
+      <stop offset="50%" stop-color="#7341FF"/>
+      <stop offset="100%" stop-color="#AA8EFF"/>
+    </linearGradient>
+
+    <!-- Shadow filter -->
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="115%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#6D4AFF" flood-opacity="0.15"/>
+    </filter>
+  </defs>
+
+  <!-- === Left: Official Proton Mail Icon (scaled to ~180px) === -->
+  <g transform="translate(50, 15) scale(5)" filter="url(#shadow)">
+    <path fill-rule="evenodd" clip-rule="evenodd"
+          d="M22.8601 13.464L22.8621 13.4656L12.8571 24.5714L0 10.4194V4.31488C0 3.61388 0.817029 3.23035 1.35631 3.67821L15.6207 15.5242C17.0001 16.6697 18.9999 16.6697 20.3793 15.5242L22.8601 13.464Z"
+          fill="url(#pm0)"/>
+    <path d="M28.2857 8.95834L22.8601 13.4641L22.8621 13.4657L15.6784 19.8113C14.4546 20.8923 12.6255 20.9196 11.3701 19.8755L0 10.4195V28.5617C0 30.6185 1.66735 32.2858 3.72414 32.2858H28.2857L30.8571 20.6221L28.2857 8.95834Z"
+          fill="url(#pm1)"/>
+    <path fill-rule="evenodd" clip-rule="evenodd"
+          d="M28.2857 8.96285V32.2857L32.2758 32.2857C34.3326 32.2857 36 30.6182 36 28.5616V4.3149C36 3.6139 35.1829 3.23031 34.6437 3.67825L28.2857 8.96285Z"
+          fill="url(#pm2)"/>
+  </g>
+
+  <!-- === Center: Bridge Connector === -->
+  <g transform="translate(280, 75)">
+    <!-- Bridge arc -->
+    <path d="M0 70 Q80 -10 160 70" fill="none" stroke="url(#bridgeGrad)" stroke-width="4" stroke-linecap="round"/>
+    <!-- Bridge pillars -->
+    <rect x="10" y="60" width="8" height="24" rx="3" fill="#7341FF"/>
+    <rect x="142" y="60" width="8" height="24" rx="3" fill="#AA8EFF"/>
+    <!-- Bridge road surface -->
+    <rect x="0" y="68" width="160" height="6" rx="3" fill="url(#bridgeGrad)" opacity="0.25"/>
+    <!-- Data flow dots -->
+    <circle r="3.5" fill="#6D4AFF" opacity="0.8">
+      <animate attributeName="cx" values="30;130" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="52;32;52" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0.5;0.9" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="3" fill="#7341FF" opacity="0.5">
+      <animate attributeName="cx" values="130;30" dur="2.4s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="35;55;35" dur="2.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.8;0.4" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="2.5" fill="#AA8EFF" opacity="0.6">
+      <animate attributeName="cx" values="45;115" dur="1.7s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="45;25;45" dur="1.7s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;0.3;0.6" dur="1.7s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- === Right: MCP Protocol Icon (Proton color scheme, sized to match mail icon) === -->
+  <g transform="translate(487, 25)" filter="url(#shadow)">
+    <!-- Rounded square background -->
+    <rect x="8" y="8" width="140" height="148" rx="22" fill="url(#mcpGrad)"/>
+    <!-- Subtle inner highlight -->
+    <rect x="15" y="15" width="126" height="134" rx="17" fill="none" stroke="white" stroke-width="1" opacity="0.12"/>
+    <!-- Central hub -->
+    <circle cx="78" cy="82" r="22" fill="white" opacity="0.95"/>
+    <text x="78" y="89" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="15" font-weight="700" fill="#6D4AFF">MCP</text>
+    <!-- Cardinal connection lines -->
+    <line x1="78" y1="60" x2="78" y2="30" stroke="white" stroke-width="2.5" opacity="0.6" stroke-linecap="round"/>
+    <line x1="100" y1="82" x2="130" y2="82" stroke="white" stroke-width="2.5" opacity="0.6" stroke-linecap="round"/>
+    <line x1="56" y1="82" x2="26" y2="82" stroke="white" stroke-width="2.5" opacity="0.6" stroke-linecap="round"/>
+    <line x1="78" y1="104" x2="78" y2="134" stroke="white" stroke-width="2.5" opacity="0.6" stroke-linecap="round"/>
+    <!-- Diagonal connection lines -->
+    <line x1="93" y1="67" x2="118" y2="42" stroke="white" stroke-width="2" opacity="0.35" stroke-linecap="round"/>
+    <line x1="63" y1="67" x2="38" y2="42" stroke="white" stroke-width="2" opacity="0.35" stroke-linecap="round"/>
+    <line x1="93" y1="97" x2="118" y2="122" stroke="white" stroke-width="2" opacity="0.35" stroke-linecap="round"/>
+    <line x1="63" y1="97" x2="38" y2="122" stroke="white" stroke-width="2" opacity="0.35" stroke-linecap="round"/>
+    <!-- Cardinal endpoint dots -->
+    <circle cx="78" cy="26" r="5" fill="white" opacity="0.85"/>
+    <circle cx="134" cy="82" r="5" fill="white" opacity="0.85"/>
+    <circle cx="22" cy="82" r="5" fill="white" opacity="0.85"/>
+    <circle cx="78" cy="138" r="5" fill="white" opacity="0.85"/>
+    <!-- Diagonal endpoint dots -->
+    <circle cx="121" cy="39" r="4" fill="white" opacity="0.6"/>
+    <circle cx="35" cy="39" r="4" fill="white" opacity="0.6"/>
+    <circle cx="121" cy="125" r="4" fill="white" opacity="0.6"/>
+    <circle cx="35" cy="125" r="4" fill="white" opacity="0.6"/>
+  </g>
+</svg>

--- a/docs/bridge-repair/README.md
+++ b/docs/bridge-repair/README.md
@@ -1,0 +1,241 @@
+# Repairing Proton Mail Bridge
+
+Proton Mail Bridge occasionally encounters sync issues, database corruption, or connectivity problems. This guide walks you through diagnosing and repairing common issues using the Bridge desktop application.
+
+---
+
+## Table of Contents
+
+- [Symptoms](#symptoms)
+- [Quick Fixes](#quick-fixes)
+- [Step-by-Step Repair](#step-by-step-repair)
+- [Full Reset (Nuclear Option)](#full-reset-nuclear-option)
+- [Verifying the Repair](#verifying-the-repair)
+
+---
+
+## Symptoms
+
+You likely need to repair Bridge if you see any of these:
+
+| Symptom | Likely Cause |
+|---|---|
+| `verify_connectivity` fails with "connection refused" | Bridge is not running or IMAP is disabled |
+| `verify_connectivity` fails with "authentication failed" | Mailbox password changed or account needs re-login |
+| `list_folders` returns stale or empty results | Bridge sync database is corrupted |
+| Emails appear in ProtonMail web but not via MCP | Bridge is stuck syncing or needs a resync |
+| Bridge shows "Update available" banner | Outdated version can cause protocol issues |
+| Bridge status indicator is red/orange | General connectivity or sync issue |
+
+---
+
+## Quick Fixes
+
+Try these first before a full repair:
+
+### 1. Restart Proton Mail Bridge
+
+The simplest fix for most transient issues.
+
+1. **Quit Bridge** completely (right-click the system tray icon > **Quit**, or use **Bridge > Quit** from the menu bar on macOS)
+2. **Wait 5 seconds** for all processes to terminate
+3. **Relaunch** Proton Mail Bridge from your Applications folder
+
+> **Tip:** After restarting Bridge, use the `drain_connections` MCP tool to force the MCP server to reconnect with fresh IMAP connections. This avoids stale connection errors.
+
+### 2. Check Bridge Status
+
+Open the Bridge window and check:
+
+- **Status indicator**: Should show a green checkmark or "Connected"
+- **Sync progress**: If Bridge is still syncing, wait for it to complete before using MCP tools
+- **IMAP/SMTP toggle**: Ensure IMAP is enabled (should show port `1143` by default)
+
+### 3. Re-enter Your Password
+
+If you recently changed your ProtonMail password or enabled/disabled 2FA:
+
+1. Open Bridge and click on your **account name**
+2. You may be prompted to **sign in again**
+3. After signing in, note the new **Mailbox password** — it may have changed
+4. Update your `.env` file or CLI flags with the new password
+
+---
+
+## Step-by-Step Repair
+
+If quick fixes don't resolve the issue, follow this repair procedure.
+
+### Step 1: Open Bridge Settings
+
+1. Open Proton Mail Bridge
+2. Click the **gear icon** (Settings) in the bottom-left corner of the Bridge window
+
+<!-- Screenshot: Bridge main window with gear icon highlighted -->
+<!-- Place screenshot at: docs/bridge-repair/screenshots/01-settings-icon.png -->
+
+### Step 2: Check for Updates
+
+1. In Settings, look for an **Update** section or banner
+2. If an update is available, **install it** and restart Bridge
+3. Many sync and connectivity issues are resolved by updating to the latest version
+
+<!-- Screenshot: Bridge settings showing update section -->
+<!-- Place screenshot at: docs/bridge-repair/screenshots/02-check-updates.png -->
+
+### Step 3: Repair Your Account
+
+This rebuilds the local sync database without removing your account.
+
+1. Go back to the main Bridge window
+2. Click on your **account name** to expand account details
+3. Look for the **"Repair"** button (it may be under an overflow menu or advanced section)
+4. Click **Repair** and confirm when prompted
+5. Bridge will resynchronize your mailbox — this can take several minutes depending on mailbox size
+
+<!-- Screenshot: Account details showing Repair button -->
+<!-- Place screenshot at: docs/bridge-repair/screenshots/03-repair-account.png -->
+
+> **Note:** During repair, the IMAP server remains running but may return incomplete results. Wait for the repair to finish before using MCP tools.
+
+### Step 4: Verify IMAP Settings
+
+After repair, confirm your IMAP settings are correct:
+
+1. Click on your **account name** in Bridge
+2. Check that **IMAP** shows as enabled
+3. Note the displayed values:
+   - **Host:** `127.0.0.1` (default)
+   - **Port:** `1143` (default)
+   - **Security:** STARTTLS
+4. If the port differs from your configuration, update your `.env` or CLI flags
+
+<!-- Screenshot: Account IMAP settings panel -->
+<!-- Place screenshot at: docs/bridge-repair/screenshots/04-imap-settings.png -->
+
+### Step 5: Copy the Mailbox Password
+
+The repair process may regenerate the mailbox password:
+
+1. In the account details panel, click **"Mailbox password"** or the copy icon next to it
+2. The bridge-generated password is copied to your clipboard
+3. Update your `.env` file:
+   ```
+   PROTONMAIL_BRIDGE_PASSWORD=new-bridge-password-here
+   ```
+4. Or update the CLI flag: `--bridge-password new-bridge-password-here`
+
+<!-- Screenshot: Mailbox password copy button -->
+<!-- Place screenshot at: docs/bridge-repair/screenshots/05-mailbox-password.png -->
+
+> **Important:** This is the Bridge-generated mailbox password, **not** your ProtonMail login password. They are different credentials.
+
+---
+
+## Full Reset (Nuclear Option)
+
+If repair doesn't work, you can remove and re-add your account. **This deletes the local cache and re-syncs everything from scratch.**
+
+### Step 1: Remove the Account
+
+1. In the Bridge main window, click on your **account name**
+2. Click **"Remove account"** (or the trash icon)
+3. Confirm the removal
+
+<!-- Screenshot: Remove account confirmation -->
+<!-- Place screenshot at: docs/bridge-repair/screenshots/06-remove-account.png -->
+
+### Step 2: Clear Bridge Cache (Optional)
+
+If the database is truly corrupted, clear the cache:
+
+**macOS:**
+```bash
+rm -rf ~/Library/Caches/protonmail/bridge-v3/
+rm -rf ~/Library/Application\ Support/protonmail/bridge-v3/cache/
+```
+
+**Linux:**
+```bash
+rm -rf ~/.cache/protonmail/bridge-v3/
+rm -rf ~/.local/share/protonmail/bridge-v3/cache/
+```
+
+**Windows:**
+```powershell
+Remove-Item -Recurse "$env:LOCALAPPDATA\protonmail\bridge-v3\cache"
+```
+
+> **Warning:** Only delete the `cache` directory. Do not delete the entire Bridge configuration directory or you'll lose all account settings.
+
+### Step 3: Re-add Your Account
+
+1. Click **"Add account"** in Bridge
+2. Sign in with your ProtonMail credentials (and 2FA if enabled)
+3. Wait for the initial sync to complete (this may take 10-30 minutes for large mailboxes)
+4. Copy the new **Mailbox password** and update your configuration
+
+### Step 4: Verify Everything Works
+
+```bash
+node dist/index.js --verify \
+  --bridge-username your@protonmail.com \
+  --bridge-password new-bridge-password
+```
+
+---
+
+## Verifying the Repair
+
+After any repair procedure, verify the MCP server can connect:
+
+```bash
+# 1. Test basic connectivity
+node dist/index.js --verify \
+  --bridge-username your@protonmail.com \
+  --bridge-password your-bridge-password
+
+# 2. If the MCP server was already running, drain stale connections
+# Use the drain_connections tool via your MCP client, or restart the server
+
+# 3. Test a read operation
+# Use list_folders via your MCP client to confirm mailboxes are visible
+```
+
+### Expected Output
+
+A successful `--verify` prints:
+
+```
+IMAP connection verified successfully (latency: XXms)
+```
+
+If you see authentication or connection errors after repair, double-check:
+
+1. Bridge is running and shows a green status
+2. The mailbox password matches (re-copy it from Bridge)
+3. The IMAP port matches your configuration (default: `1143`)
+4. No firewall is blocking localhost connections on that port
+
+---
+
+## Adding Screenshots
+
+This guide includes placeholder comments for screenshots. To add them:
+
+1. Create the screenshots directory:
+   ```bash
+   mkdir -p docs/bridge-repair/screenshots
+   ```
+
+2. Take screenshots of each step in the Proton Mail Bridge app and save them as:
+   - `01-settings-icon.png`
+   - `02-check-updates.png`
+   - `03-repair-account.png`
+   - `04-imap-settings.png`
+   - `05-mailbox-password.png`
+   - `06-remove-account.png`
+
+3. Uncomment the image references in this file to display them.
+
+> **Privacy note:** Before committing screenshots, ensure they do not contain your email address, account name, or any other personal information. Redact or blur sensitive areas.

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,0 +1,387 @@
+# MCP Tools Reference
+
+This document describes every tool exposed by the proton-bridge-mcp server. Each tool listing includes its MCP annotations, input schema, and return type.
+
+**Annotations** tell the MCP client how the tool behaves:
+
+| Annotation | Meaning |
+|---|---|
+| `readOnlyHint: true` | The tool does not modify any data |
+| `destructiveHint: true` | The tool may irreversibly change data |
+
+All batch operations preserve input order — `result[i]` always corresponds to `input[i]`. Individual item failures are reported per-item (with `error.code` and `error.message`), while top-level failures return a tool error.
+
+---
+
+## Table of Contents
+
+- [Read Operations](#read-operations)
+  - [list_folders](#list_folders)
+  - [list_mailbox](#list_mailbox)
+  - [fetch_summaries](#fetch_summaries)
+  - [fetch_message](#fetch_message)
+  - [fetch_attachment](#fetch_attachment)
+  - [search_mailbox](#search_mailbox)
+- [Write Operations](#write-operations)
+  - [move_emails](#move_emails)
+  - [mark_read](#mark_read)
+  - [mark_unread](#mark_unread)
+- [Maintenance](#maintenance)
+  - [verify_connectivity](#verify_connectivity)
+  - [drain_connections](#drain_connections)
+- [Shared Types](#shared-types)
+
+---
+
+## Read Operations
+
+### `list_folders`
+
+List all IMAP mailboxes/folders available in the ProtonMail account. Returns folder paths, names, hierarchy delimiters, and special-use flags (Sent, Drafts, Trash, etc.).
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Input** | _(none)_ |
+
+**Returns:** `FolderInfo[]`
+
+```jsonc
+[
+  {
+    "path": "INBOX",              // Full hierarchy path
+    "name": "INBOX",              // Leaf name
+    "delimiter": "/",             // Hierarchy delimiter
+    "flags": ["\\HasNoChildren"], // IMAP folder attributes
+    "specialUse": "\\Inbox"       // RFC 6154 special-use (optional)
+  },
+  {
+    "path": "Folders/Work",
+    "name": "Work",
+    "delimiter": "/",
+    "flags": ["\\HasNoChildren"],
+    "specialUse": null
+  }
+]
+```
+
+---
+
+### `list_mailbox`
+
+List emails in a ProtonMail mailbox, newest first. Returns envelope summaries (no body content).
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `mailbox` | `string` | `"INBOX"` | Mailbox name (e.g. `INBOX`, `Sent`, `Trash`, `Folders/Work`) |
+| `limit` | `integer` | `20` | Max emails to return (1–100) |
+| `offset` | `integer` | `0` | Number of emails to skip from newest |
+
+**Returns:** [`EmailSummary[]`](#emailsummary)
+
+---
+
+### `fetch_summaries`
+
+Fetch envelope summaries for a list of known email IDs. Use this when you already have specific UIDs (e.g. from a previous `list_mailbox` or `search_mailbox` call) and want to refresh their metadata.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `ids` | [`EmailId[]`](#emailid) | Email IDs to fetch (1–50) |
+
+**Returns:** [`EmailSummary[]`](#emailsummary)
+
+---
+
+### `fetch_message`
+
+Fetch full message content (text/HTML body + attachment metadata) for a list of email IDs. Attachment binary content is **not** included — use `fetch_attachment` to download individual attachments.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `ids` | [`EmailId[]`](#emailid) | Email IDs to fetch (1–20) |
+
+**Returns:** `EmailMessage[]`
+
+```jsonc
+[
+  {
+    // ...all EmailSummary fields, plus:
+    "textBody": "Hello, this is the plain text body...",   // optional
+    "htmlBody": "<html><body>Hello...</body></html>",      // optional
+    "attachments": [
+      {
+        "partId": "2",                // IMAP body part ID — pass to fetch_attachment
+        "filename": "report.pdf",     // optional
+        "contentType": "application/pdf",
+        "size": 245760                // bytes
+      }
+    ]
+  }
+]
+```
+
+---
+
+### `fetch_attachment`
+
+Download a single email attachment by its IMAP part ID (obtained from `fetch_message` results). Returns the binary content as a base64-encoded string.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | [`EmailId`](#emailid) | The email containing the attachment |
+| `partId` | `string` | Attachment part ID from `fetch_message` (e.g. `"2"`, `"1.2"`) |
+
+**Returns:** `AttachmentContent`
+
+```jsonc
+{
+  "emailId": { "uid": 42, "mailbox": "INBOX" },
+  "partId": "2",
+  "filename": "report.pdf",        // optional
+  "contentType": "application/pdf",
+  "data": "JVBERi0xLjQK...",       // base64-encoded binary content
+  "size": 245760                    // bytes
+}
+```
+
+---
+
+### `search_mailbox`
+
+Search for emails in a mailbox by text query. Uses IMAP `TEXT` search, which matches against all message fields (headers, body, etc.). Returns summaries of matching emails.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `mailbox` | `string` | `"INBOX"` | Mailbox to search in |
+| `query` | `string` | _(required)_ | Text to search for |
+| `limit` | `integer` | `20` | Max results to return (1–100) |
+| `offset` | `integer` | `0` | Number of results to skip |
+
+**Returns:** [`EmailSummary[]`](#emailsummary)
+
+---
+
+## Write Operations
+
+### `move_emails`
+
+Move a batch of emails to a target mailbox. Returns per-email results with source/target info and new UIDs.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` |
+
+> **Destructive:** Moving an email changes its UID and mailbox. The original UID becomes invalid.
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `ids` | [`EmailId[]`](#emailid) | Emails to move (1–50) |
+| `targetMailbox` | `string` | Destination mailbox (e.g. `Archive`, `Trash`, `Folders/Work`) |
+
+**Returns:** `BatchItemResult<MoveResult>[]`
+
+```jsonc
+[
+  {
+    "id": { "uid": 42, "mailbox": "INBOX" },
+    "data": {
+      "fromMailbox": "INBOX",
+      "toMailbox": "Archive",
+      "targetId": { "uid": 108, "mailbox": "Archive" }  // new UID, or null if unknown
+    }
+  },
+  {
+    "id": { "uid": 99, "mailbox": "INBOX" },
+    "error": { "code": "NOT_FOUND", "message": "UID 99 not found in INBOX" }
+  }
+]
+```
+
+---
+
+### `mark_read`
+
+Mark a batch of emails as read by adding the `\Seen` IMAP flag.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `ids` | [`EmailId[]`](#emailid) | Emails to mark as read (1–50) |
+
+**Returns:** `BatchItemResult<FlagResult>[]`
+
+```jsonc
+[
+  {
+    "id": { "uid": 42, "mailbox": "INBOX" },
+    "data": {
+      "flagsAfter": ["\\Seen", "\\Flagged"]   // full flag set after the operation
+    }
+  }
+]
+```
+
+---
+
+### `mark_unread`
+
+Mark a batch of emails as unread by removing the `\Seen` IMAP flag.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `ids` | [`EmailId[]`](#emailid) | Emails to mark as unread (1–50) |
+
+**Returns:** `BatchItemResult<FlagResult>[]`
+
+_(Same structure as `mark_read` — see above.)_
+
+---
+
+## Maintenance
+
+### `verify_connectivity`
+
+Test the connection to the Proton Bridge IMAP server. Acquires a connection from the pool, measures latency, and releases it. Use this to check if Bridge is running and reachable.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Input** | _(none)_ |
+
+**Returns:**
+
+```jsonc
+{
+  "success": true,
+  "latencyMs": 12          // round-trip time in milliseconds
+}
+// or on failure:
+{
+  "success": false,
+  "error": "Connection refused"
+}
+```
+
+---
+
+### `drain_connections`
+
+Close all connections in the IMAP connection pool immediately. Useful for forcing reconnection after a Proton Bridge restart, or to recover from stale connection errors.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Input** | _(none)_ |
+
+**Returns:**
+
+```jsonc
+{
+  "message": "Drained 3 connections"
+}
+```
+
+---
+
+## Shared Types
+
+### `EmailId`
+
+Stable identifier for an email. UIDs are unique within a mailbox but not globally.
+
+```typescript
+{
+  uid: number;      // IMAP UID (positive integer)
+  mailbox: string;  // Mailbox path, e.g. "INBOX"
+}
+```
+
+### `EmailAddress`
+
+RFC 5321 email address with optional display name.
+
+```typescript
+{
+  address: string;  // e.g. "alice@example.com"
+  name?: string;    // e.g. "Alice Smith"
+}
+```
+
+### `EmailSummary`
+
+Envelope metadata for an email (no body content).
+
+```typescript
+{
+  id: EmailId;
+  messageId?: string;         // RFC 2822 Message-ID
+  from: EmailAddress;
+  to: EmailAddress[];
+  cc: EmailAddress[];
+  replyTo: EmailAddress[];
+  subject: string;
+  date?: Date;                // ISO 8601 string in JSON
+  size?: number;              // bytes
+  flags: string[];            // e.g. ["\\Seen", "\\Flagged"]
+  hasAttachments: boolean;
+}
+```
+
+### `BatchItemResult<T>`
+
+Per-item result for batch operations. Either `data` or `error` is present, never both.
+
+```typescript
+{
+  id: EmailId;
+  data?: T;                   // present on success
+  error?: {
+    code: string;             // e.g. "NOT_FOUND", "LOCK_FAILED"
+    message: string;
+  };
+}
+```


### PR DESCRIPTION
## Summary

- Replaces placeholder README with a full project README featuring an SVG logo (official Proton Mail icon + MCP graphic with animated bridge connector), MCPB quick-start guide, security recommendations, troubleshooting section, and complete configuration reference
- Extracts MCP tool documentation into `docs/tools/README.md` with full input schemas, return types, annotations, and example JSON
- Adds a Proton Bridge repair guide at `docs/bridge-repair/README.md` with step-by-step instructions for diagnosing and fixing common Bridge issues

## New files

| File | Purpose |
|---|---|
| `assets/logo.svg` | Project logo (Proton Mail icon + bridge + MCP node) |
| `docs/tools/README.md` | Full MCP tools reference with schemas and examples |
| `docs/bridge-repair/README.md` | Bridge troubleshooting and repair guide |

## README sections

Features, Prerequisites, Quick Start (MCPB), Other Usage (STDIO/HTTP/HTTPS), Authentication, Configuration Reference, MCP Tools (summary + link), Claude Desktop Manual Configuration, Security, Troubleshooting, Development, Architecture, Contributing, Acknowledgements, License, Proton trademark notice

## Test plan

- [ ] Verify logo renders on GitHub (SVG in `assets/`)
- [ ] Verify all internal anchor links in README resolve correctly
- [ ] Verify links to `docs/tools/README.md` and `docs/bridge-repair/README.md` work
- [ ] Confirm no code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)