### PR TITLE
ci: release workflow with MCPB, source archive, and npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   release:
-    name: Create GitHub Release
+    name: Create GitHub Release & Publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,9 +24,24 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
+          registry-url: "https://registry.npmjs.org"
 
       - run: npm ci
       - run: npm run build
+
+      - name: Build MCPB package
+        run: bash scripts/build-mcpb.sh
+
+      - name: Create source archive
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          tar czf "proton-bridge-mcp-${VERSION}-source.tar.gz" \
+            --exclude=node_modules \
+            --exclude=.git \
+            --exclude=dist \
+            --exclude=.mcpb-staging \
+            --exclude='*.mcpb' \
+            .
 
       - name: Extract changelog for this version
         run: |
@@ -39,3 +54,11 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body_path: release-notes.txt
+          files: |
+            proton-bridge-mcp.mcpb
+            proton-bridge-mcp-*-source.tar.gz
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -11,7 +11,7 @@
     "release": false
   },
   "npm": {
-    "publish": false
+    "publish": true
   },
   "plugins": {
     "@release-it/keep-a-changelog": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Release workflow attaches `proton-bridge-mcp.mcpb` and source archive (`proton-bridge-mcp-X.Y.Z-source.tar.gz`) to GitHub Releases
+- npm publish on release via `NPM_TOKEN` secret; `package.json` `files` field limits tarball to `dist/`, `manifest.json`, `CHANGELOG.md`, and `LICENSE`
 - GitHub Actions CI workflow (`.github/workflows/ci.yml`): parallel Lint, Build, Test jobs with concurrency cancellation and npm caching
 - GitHub Actions release workflow (`.github/workflows/release.yml`): triggered on version tag push, extracts changelog section, creates GitHub Release
 - `release-it` + `@release-it/keep-a-changelog` for local release automation (bumps version, rewrites `CHANGELOG.md`, pushes tag)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,15 @@ Required status checks to configure in GitHub branch protection: **Lint**, **Bui
    - Moves `[Unreleased]` → `[x.y.z]` in `CHANGELOG.md`
    - Bumps `package.json` version
    - Commits `chore: release vX.Y.Z` and pushes tag
-3. `release.yml` fires on the tag → extracts the changelog section via `awk` → creates GitHub Release
+3. `release.yml` fires on the tag → builds → creates GitHub Release with:
+   - `proton-bridge-mcp.mcpb` — Claude Desktop package
+   - `proton-bridge-mcp-X.Y.Z-source.tar.gz` — source archive (excludes `node_modules`, `.git`, `dist`)
+   - Changelog section extracted via `awk`
+4. Same workflow publishes to npm (`npm publish --access public`)
 
 `github.release: false` in `.release-it.json` — GitHub Release is always created by CI, never from a local machine.
-To enable npm publish: set `"publish": true` in `.release-it.json` and add `NPM_TOKEN` to GitHub Secrets.
+npm publish is enabled (`"publish": true`); requires `NPM` secret in GitHub repo settings.
+`package.json` `files` field limits the npm tarball to `dist/`, `manifest.json`, `CHANGELOG.md`, and `LICENSE`.
 
 ### Node version pinning
 - `.nvmrc`: `25.9.0` — nvm/mise/asdf local dev

--- a/README.md
+++ b/README.md
@@ -544,7 +544,11 @@ PRs are reviewed and merged by the maintainer. This is a side project — respon
 
 ### Releases
 
-Releases are managed with [release-it](https://github.com/release-it/release-it). Maintainers run `npx release-it` locally, which bumps the version, updates the changelog, and pushes a tag. CI then creates the GitHub Release automatically.
+Releases are managed with [release-it](https://github.com/release-it/release-it). Maintainers run `npx release-it` locally, which bumps the version, updates the changelog, and pushes a tag. CI then creates the GitHub Release automatically with:
+
+- **`proton-bridge-mcp.mcpb`** — ready-to-install Claude Desktop package
+- **`proton-bridge-mcp-X.Y.Z-source.tar.gz`** — source archive
+- **npm** — the package is published to [npm](https://www.npmjs.com/package/proton-bridge-mcp) (`npm install -g proton-bridge-mcp`)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
   "bin": {
     "proton-bridge-mcp": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "manifest.json",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "dev": "tsx watch src/index.ts",


### PR DESCRIPTION
## Summary

- Release workflow now builds and attaches `proton-bridge-mcp.mcpb` and a source archive to GitHub Releases
- Adds npm publish step using the `NPM` repository secret
- Adds `files` field to `package.json` to limit the npm tarball to `dist/`, `manifest.json`, `CHANGELOG.md`, and `LICENSE`
- Enables `"publish": true` in `.release-it.json`
- Updates CLAUDE.md, README.md, and CHANGELOG.md to reflect the full release pipeline

## Test plan

- [ ] Merge PR and verify CI passes
- [ ] Run `npx release-it` to create a tag and verify the release workflow:
  - [ ] GitHub Release is created with `.mcpb` and source archive attached
  - [ ] Package is published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)