### PR TITLE
chore: add npm release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint 'src/**/*.ts'",
     "test": "echo 'No tests yet — add vitest and update this script' && exit 0",
     "inspector": "npm run build && bash scripts/run_inspector.sh",
-    "package": "npm run build && bash scripts/build-mcpb.sh"
+    "package": "npm run build && bash scripts/build-mcpb.sh",
+    "release": "git checkout main && git pull origin main && npx release-it"
   },
   "volta": {
     "node": "25.9.0"


### PR DESCRIPTION
## Summary

- Adds `npm run release` script that checks out main, pulls latest, and launches `npx release-it`

## Test plan

- [ ] Run `npm run release` and verify it switches to main, pulls, and starts the release-it prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)