### PR TITLE
feat: add add_labels tool — bulk add Proton labels to emails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ HTTP Client (Claude Desktop / MCP Inspector)
 ┌──────────────────▼──────────────────────────┐
 │  McpServer  (src/server.ts)                 │
 │  createMcpServer(imap, pool)                │
-│  ─ 10 registered tools                      │
+│  ─ 12 registered tools                      │
 │  ─ created fresh per HTTP session           │
 │  ─ imap + pool are shared singletons        │
 └──────────────────┬──────────────────────────┘
@@ -110,7 +110,7 @@ Sessions keyed by `mcp-session-id` header. `reply.hijack()` before passing to tr
 `server.connect(transport)` requires a cast due to MCP SDK `exactOptionalPropertyTypes` mismatch on `onclose`.
 
 ### `src/server.ts` — `createMcpServer(imap, pool)`
-Registers 10 tools. Called once per HTTP session. Tool handler pattern:
+Registers 12 tools. Called once per HTTP session. Tool handler pattern:
 ```typescript
 server.tool(name, description, zodRawShape, async (args) => ({
   content: [{ type: 'text', text: JSON.stringify(await handler(args, imap)) }],
@@ -134,6 +134,10 @@ FolderInfo          { path, name, delimiter, flags: string[], specialUse? }
 BatchItemResult<T>  { id: EmailId, data?: T, error?: { code, message } }
   MoveResult        { fromMailbox, toMailbox, targetId? }
   FlagResult        { flagsAfter: string[] }
+
+AddLabelsBatchResult  { items: AddLabelsItem[] }
+  AddLabelsItem       { id, data?: AddLabelsItemData[], error? }
+    AddLabelsItemData { labelPath, newId?: EmailId }
 ```
 
 ## Tool Inventory
@@ -150,6 +154,7 @@ BatchItemResult<T>  { id: EmailId, data?: T, error?: { code, message } }
 | `mark_read` | `ids` | `FlagBatchResult` | UID STORE +FLAGS (\\Seen) |
 | `mark_unread` | `ids` | `FlagBatchResult` | UID STORE -FLAGS (\\Seen) |
 | `verify_connectivity` | — | `{ success, latencyMs? }` | connect + NOOP |
+| `add_labels` | `ids`, `labelNames` | `AddLabelsBatchResult` | UID COPY per item/label |
 | `drain_connections` | — | `{ message }` | pool.drain() |
 
 ## Batch Contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `add_labels` MCP tool — add one or more Proton Mail labels to a batch of emails via IMAP COPY; returns per-email results including new UIDs in label folders
+- `AddLabelsBatchResult`, `AddLabelsItem`, `AddLabelsItemData` types in `src/types/operations.ts`
+
+### Changed
+
 - Simplified the release
 
 ## [0.2.0] - 2026-04-04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ import { ImapClient } from './bridge/imap';      // ✗ fails at runtime
 | `mark_read` | Add `\Seen` flag (batch) |
 | `mark_unread` | Remove `\Seen` flag (batch) |
 | `verify_connectivity` | Test IMAP connection to Proton Bridge |
+| `add_labels` | Add Proton Mail labels to a batch of emails (IMAP COPY) |
 | `drain_connections` | Flush all pool connections immediately |
 
 ## Verify Setup

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ An [MCP](https://modelcontextprotocol.io/) server that bridges ProtonMail to AI 
 
 ## Features
 
-- **11 MCP tools** for reading, searching, and organizing email
+- **12 MCP tools** for reading, searching, and organizing email
 - **Three transport modes** — STDIO, HTTP, and HTTPS
 - **IMAP connection pooling** with configurable min/max connections and idle drain timers
 - **Batch operations** with input-order stability and per-item error reporting
@@ -234,7 +234,7 @@ All environment variables use the `PROTONMAIL_` prefix. You can set them in a `.
 
 ## MCP Tools
 
-The server exposes 11 tools that MCP clients can call. Each tool is annotated with `readOnlyHint` or `destructiveHint` so clients can present appropriate confirmation prompts.
+The server exposes 12 tools that MCP clients can call. Each tool is annotated with `readOnlyHint` or `destructiveHint` so clients can present appropriate confirmation prompts.
 
 For **full documentation** — including input schemas, return types, and example JSON — see the **[Tools Reference](docs/tools/README.md)**.
 
@@ -249,6 +249,7 @@ For **full documentation** — including input schemas, return types, and exampl
 | `move_emails` | destructive | Move a batch of emails to another mailbox |
 | `mark_read` | mutating | Add the `\Seen` flag to a batch of emails |
 | `mark_unread` | mutating | Remove the `\Seen` flag from a batch of emails |
+| `add_labels` | mutating | Add Proton Mail labels to a batch of emails (IMAP COPY) |
 | `verify_connectivity` | read-only | Test connection to Proton Bridge and report latency |
 | `drain_connections` | read-only | Close all pooled connections (useful after a Bridge restart) |
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -26,6 +26,7 @@ All batch operations preserve input order — `result[i]` always corresponds to 
   - [move_emails](#move_emails)
   - [mark_read](#mark_read)
   - [mark_unread](#mark_unread)
+  - [add_labels](#add_labels)
 - [Maintenance](#maintenance)
   - [verify_connectivity](#verify_connectivity)
   - [drain_connections](#drain_connections)
@@ -278,6 +279,51 @@ Mark a batch of emails as unread by removing the `\Seen` IMAP flag.
 **Returns:** `BatchItemResult<FlagResult>[]`
 
 _(Same structure as `mark_read` — see above.)_
+
+---
+
+### `add_labels`
+
+Add one or more Proton Mail labels to a batch of emails. Each email is copied into the corresponding label folder via IMAP COPY, so it simultaneously remains in its original folder. Returns per-email results including the new UID in each label folder.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `ids` | [`EmailId[]`](#emailid) | Emails to label (1–50) |
+| `labelNames` | `string[]` | Label names to apply (plain names without `Labels/` prefix, 1+) |
+
+**Returns:** `AddLabelsBatchResult`
+
+```jsonc
+{
+  "items": [
+    {
+      "id": { "uid": 42, "mailbox": "INBOX" },
+      "data": [
+        {
+          "labelPath": "Labels/Important",
+          "newId": { "uid": 7, "mailbox": "Labels/Important" }
+        },
+        {
+          "labelPath": "Labels/Work",
+          "newId": { "uid": 12, "mailbox": "Labels/Work" }
+        }
+      ]
+    },
+    {
+      "id": { "uid": 99, "mailbox": "INBOX" },
+      "error": { "code": "COPY_FAILED", "message": "UID 99 not found in INBOX" }
+    }
+  ]
+}
+```
+
+> **Note:** If a requested label does not exist as an IMAP folder (e.g. `Labels/Foo`), the corresponding entry in `data` will have `labelPath` but no `newId`. If **all** requested labels are missing, the item reports a `LABEL_NOT_FOUND` error instead.
 
 ---
 

--- a/src/bridge/imap.ts
+++ b/src/bridge/imap.ts
@@ -17,6 +17,9 @@ import type {
   BatchItemResult,
   MoveResult,
   FlagResult,
+  AddLabelsBatchResult,
+  AddLabelsItem,
+  AddLabelsItemData,
 } from '../types/index.js';
 
 export class ImapClient {
@@ -290,6 +293,85 @@ export class ImapClient {
     }
 
     return results as FlagBatchResult;
+  }
+
+  @Audited('add_labels')
+  async addLabels(ids: EmailId[], labelNames: string[]): Promise<AddLabelsBatchResult> {
+    // Prepend "Labels/" to each label name
+    const labelPaths = labelNames.map(name => `Labels/${name}`);
+
+    // Validate that all label paths exist
+    const conn0 = await this.#pool.acquire();
+    let existingPaths: Set<string>;
+    try {
+      const mailboxes = await conn0.list();
+      existingPaths = new Set(mailboxes.map(mb => mb.path));
+    } finally {
+      this.#pool.release(conn0);
+    }
+
+    const missingLabels = labelPaths.filter(lp => !existingPaths.has(lp));
+
+    // Initialise results array preserving input order
+    const items: AddLabelsItem[] = ids.map(id => ({ id }));
+
+    // If all labels are missing, short-circuit with per-item errors
+    if (missingLabels.length === labelPaths.length) {
+      for (let i = 0; i < ids.length; i++) {
+        const id = ids[i]!;
+        items[i] = {
+          id,
+          error: { code: 'LABEL_NOT_FOUND', message: `Labels not found: ${missingLabels.join(', ')}` },
+        };
+      }
+      return { items };
+    }
+
+    const validLabelPaths = labelPaths.filter(lp => existingPaths.has(lp));
+    const groups = groupByMailbox(ids);
+
+    for (const [mailbox, mailboxIds] of groups) {
+      const conn = await this.#pool.acquire();
+      const lock = await conn.getMailboxLock(mailbox);
+      try {
+        for (const id of mailboxIds) {
+          const idx = ids.indexOf(id);
+          const labelResults: AddLabelsItemData[] = [];
+          let itemError: { code: string; message: string } | undefined;
+
+          // Report missing labels
+          for (const lp of missingLabels) {
+            labelResults.push({ labelPath: lp });
+          }
+
+          // Copy to each valid label folder
+          for (const labelPath of validLabelPaths) {
+            try {
+              const copied = await conn.messageCopy(String(id.uid), labelPath, { uid: true });
+              const targetUid = copied !== false ? copied.uidMap?.get(id.uid) : undefined;
+              labelResults.push({
+                labelPath,
+                ...(targetUid ? { newId: { uid: targetUid, mailbox: labelPath } } : {}),
+              });
+            } catch (err) {
+              itemError = { code: 'COPY_FAILED', message: err instanceof Error ? err.message : String(err) };
+              break;
+            }
+          }
+
+          if (itemError) {
+            items[idx] = { id, error: itemError };
+          } else {
+            items[idx] = { id, data: labelResults };
+          }
+        }
+      } finally {
+        lock.release();
+        this.#pool.release(conn);
+      }
+    }
+
+    return { items };
   }
 
   /** Shared helper: fetch per mailbox group, reorder to match input order */

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,6 +13,7 @@ import {
   markUnreadSchema,         handleMarkUnread,
   verifyConnectivitySchema, handleVerifyConnectivity,
   drainConnectionsSchema,   handleDrainConnections,
+  addLabelsSchema,          handleAddLabels,
 } from './tools/index.js';
 
 function toText(data: unknown): string {
@@ -165,6 +166,18 @@ export function createMcpServer(
     },
     async () => ({
       content: [{ type: 'text', text: toText(await handleDrainConnections(pool)) }],
+    }),
+  );
+
+  server.registerTool(
+    'add_labels',
+    {
+      description: 'Add one or more Proton Mail labels to a batch of emails. Each email is copied into the corresponding label folder and simultaneously remains in its original folder. Supports up to 50 emails per call. Returns per-email results including the new UID in each label folder, which is used internally to enable label removal and revert.',
+      inputSchema: addLabelsSchema,
+      annotations: MUTATING,
+    },
+    async (args) => ({
+      content: [{ type: 'text', text: toText(await handleAddLabels(args, imap)) }],
     }),
   );
 

--- a/src/tools/add-labels.ts
+++ b/src/tools/add-labels.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import type { ImapClient } from '../bridge/imap.js';
+import type { AddLabelsBatchResult } from '../types/index.js';
+
+const emailIdSchema = z.object({
+  uid:     z.number().int().positive().describe('IMAP UID'),
+  mailbox: z.string().min(1).describe('Source mailbox name'),
+});
+
+export const addLabelsSchema = {
+  ids: z.array(emailIdSchema).min(1).max(50)
+    .describe('Emails to label'),
+  labelNames: z.array(z.string().min(1)).min(1)
+    .describe('Label names to apply (plain names without "Labels/" prefix)'),
+};
+
+export async function handleAddLabels(
+  args: { ids: Array<{ uid: number; mailbox: string }>; labelNames: string[] },
+  imap: ImapClient,
+): Promise<AddLabelsBatchResult> {
+  return imap.addLabels(args.ids, args.labelNames);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,3 +9,4 @@ export * from './mark-read.js';
 export * from './mark-unread.js';
 export * from './verify-connectivity.js';
 export * from './drain-connections.js';
+export * from './add-labels.js';

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -24,5 +24,24 @@ export interface FlagResult {
   flagsAfter: string[];
 }
 
+/** Result of a single label application to one email */
+export interface AddLabelsItemData {
+  labelPath: string;
+  /** New UID in the label folder. May be undefined if the server doesn't report COPYUID. */
+  newId?:    EmailId;
+}
+
+/** Per-email result for add_labels */
+export interface AddLabelsItem {
+  id:     EmailId;
+  data?:  AddLabelsItemData[];
+  error?: { code: string; message: string };
+}
+
+/** Batch result for add_labels */
+export interface AddLabelsBatchResult {
+  items: AddLabelsItem[];
+}
+
 export type MoveBatchResult = BatchItemResult<MoveResult>[];
 export type FlagBatchResult = BatchItemResult<FlagResult>[];


### PR DESCRIPTION
## Summary

- Adds `add_labels` MCP tool that copies emails into Proton Mail label folders via IMAP COPY, allowing emails to carry multiple labels simultaneously
- Returns per-email results with new UIDs in label folders; reports `LABEL_NOT_FOUND` when all requested labels are missing, and `COPY_FAILED` for individual IMAP errors
- Validates label folder existence upfront by listing mailboxes before attempting copies

Closes #19

## Test plan

- [ ] Verify `add_labels` with valid label names returns `data` with `newId` for each label
- [ ] Verify `add_labels` with all-invalid label names returns `LABEL_NOT_FOUND` error per item
- [ ] Verify `add_labels` with a mix of valid/invalid label names returns `data` entries (missing labels lack `newId`)
- [ ] Verify batch of emails across multiple mailboxes preserves input order in results
- [ ] Verify `npm run lint` and `npm run build` pass clean
- [ ] Verify tool appears in MCP Inspector tool list with correct schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)