### PR TITLE
refactor: simplify add_labels — remove pre-check, single connection, extract BatchItemError

### DIFF
--- a/src/bridge/imap.ts
+++ b/src/bridge/imap.ts
@@ -17,6 +17,7 @@ import type {
   MoveBatchResult,
   FlagBatchResult,
   BatchItemResult,
+  BatchItemError,
   MoveResult,
   FlagResult,
   AddLabelsBatchResult,
@@ -320,78 +321,46 @@ export class ImapClient {
 
   @Audited('add_labels')
   async addLabels(ids: EmailId[], labelNames: string[]): Promise<AddLabelsBatchResult> {
-    // Prepend "Labels/" to each label name
     const labelPaths = labelNames.map(name => `Labels/${name}`);
-
-    // Validate that all label paths exist
-    const conn0 = await this.#pool.acquire();
-    let existingPaths: Set<string>;
-    try {
-      const mailboxes = await conn0.list();
-      existingPaths = new Set(mailboxes.map(mb => mb.path));
-    } finally {
-      this.#pool.release(conn0);
-    }
-
-    const missingLabels = labelPaths.filter(lp => !existingPaths.has(lp));
-
-    // Initialise results array preserving input order
     const items: AddLabelsItem[] = ids.map(id => ({ id }));
-
-    // If all labels are missing, short-circuit with per-item errors
-    if (missingLabels.length === labelPaths.length) {
-      for (let i = 0; i < ids.length; i++) {
-        const id = ids[i]!;
-        items[i] = {
-          id,
-          error: { code: 'LABEL_NOT_FOUND', message: `Labels not found: ${missingLabels.join(', ')}` },
-        };
-      }
-      return { items };
-    }
-
-    const validLabelPaths = labelPaths.filter(lp => existingPaths.has(lp));
     const groups = groupByMailbox(ids);
 
-    for (const [mailbox, mailboxIds] of groups) {
-      const conn = await this.#pool.acquire();
-      const lock = await conn.getMailboxLock(mailbox);
-      try {
-        for (const id of mailboxIds) {
-          const idx = ids.indexOf(id);
-          const labelResults: AddLabelsItemData[] = [];
-          let itemError: { code: string; message: string } | undefined;
+    const conn = await this.#pool.acquire();
+    try {
+      for (const [mailbox, mailboxIds] of groups) {
+        const lock = await conn.getMailboxLock(mailbox);
+        try {
+          for (const id of mailboxIds) {
+            const idx = ids.indexOf(id);
+            const labelResults: AddLabelsItemData[] = [];
+            let itemError: BatchItemError | undefined;
 
-          // Report missing labels
-          for (const lp of missingLabels) {
-            labelResults.push({ labelPath: lp });
-          }
+            for (const labelPath of labelPaths) {
+              try {
+                const copied = await conn.messageCopy(String(id.uid), labelPath, { uid: true });
+                const targetUid = copied !== false ? copied.uidMap?.get(id.uid) : undefined;
+                labelResults.push({
+                  labelPath,
+                  ...(targetUid ? { newId: { uid: targetUid, mailbox: labelPath } } : {}),
+                });
+              } catch (err) {
+                itemError = { code: 'COPY_FAILED', message: err instanceof Error ? err.message : String(err) };
+                break;
+              }
+            }
 
-          // Copy to each valid label folder
-          for (const labelPath of validLabelPaths) {
-            try {
-              const copied = await conn.messageCopy(String(id.uid), labelPath, { uid: true });
-              const targetUid = copied !== false ? copied.uidMap?.get(id.uid) : undefined;
-              labelResults.push({
-                labelPath,
-                ...(targetUid ? { newId: { uid: targetUid, mailbox: labelPath } } : {}),
-              });
-            } catch (err) {
-              itemError = { code: 'COPY_FAILED', message: err instanceof Error ? err.message : String(err) };
-              break;
+            if (itemError) {
+              items[idx] = { id, error: itemError };
+            } else {
+              items[idx] = { id, data: labelResults };
             }
           }
-
-          if (itemError) {
-            items[idx] = { id, error: itemError };
-          } else {
-            items[idx] = { id, data: labelResults };
-          }
+        } finally {
+          lock.release();
         }
-      } finally {
-        lock.release();
-        this.#pool.release(conn);
       }
+    } finally {
+      this.#pool.release(conn);
     }
 
     return { items };

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -1,5 +1,11 @@
 import type { EmailId } from './email.js';
 
+/** Shared error shape for per-item batch failures. */
+export interface BatchItemError {
+  code:    string;
+  message: string;
+}
+
 /**
  * Per-item result for batch mutating operations.
  * Index-stable: result[i] always corresponds to input[i].
@@ -7,7 +13,7 @@ import type { EmailId } from './email.js';
 export interface BatchItemResult<T> {
   id:     EmailId;
   data?:  T;
-  error?: { code: string; message: string };
+  error?: BatchItemError;
 }
 
 /** Result of a single email move */
@@ -35,7 +41,7 @@ export interface AddLabelsItemData {
 export interface AddLabelsItem {
   id:     EmailId;
   data?:  AddLabelsItemData[];
-  error?: { code: string; message: string };
+  error?: BatchItemError;
 }
 
 /** Batch result for add_labels */


### PR DESCRIPTION
## Summary
- Remove TOCTOU-prone label existence pre-check — let IMAP COPY fail naturally if the label doesn't exist
- Consolidate from per-group connection acquisition to a single connection for all mailbox groups
- Extract shared `BatchItemError` interface, replacing inline `{ code: string; message: string }` in `BatchItemResult<T>` and `AddLabelsItem`

Closes #19 (follow-up simplification)

## Test plan
- [ ] `add_labels` works with valid labels (copies succeed, UIDs returned)
- [ ] `add_labels` with a non-existent label returns per-item `COPY_FAILED` error
- [ ] Batch operations across multiple mailboxes preserve index order

🤖 Generated with [Claude Code](https://claude.com/claude-code)