### PR TITLE
feat: add create_folder tool — create custom mail folders

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ HTTP Client (Claude Desktop / MCP Inspector)
 ┌──────────────────▼──────────────────────────┐
 │  McpServer  (src/server.ts)                 │
 │  createMcpServer(imap, pool)                │
-│  ─ 12 registered tools                      │
+│  ─ 13 registered tools                      │
 │  ─ created fresh per HTTP session           │
 │  ─ imap + pool are shared singletons        │
 └──────────────────┬──────────────────────────┘
@@ -110,7 +110,7 @@ Sessions keyed by `mcp-session-id` header. `reply.hijack()` before passing to tr
 `server.connect(transport)` requires a cast due to MCP SDK `exactOptionalPropertyTypes` mismatch on `onclose`.
 
 ### `src/server.ts` — `createMcpServer(imap, pool)`
-Registers 12 tools. Called once per HTTP session. Tool handler pattern:
+Registers 13 tools. Called once per HTTP session. Tool handler pattern:
 ```typescript
 server.tool(name, description, zodRawShape, async (args) => ({
   content: [{ type: 'text', text: JSON.stringify(await handler(args, imap)) }],
@@ -130,6 +130,7 @@ AttachmentMetadata  { partId, filename?, contentType, size }
 AttachmentContent   { emailId, partId, filename?, contentType, data (base64), size }
 
 FolderInfo          { path, name, delimiter, listed, subscribed, flags: string[], specialUse?, messageCount, unreadCount, uidNext }
+CreateFolderResult  { path, created }
 
 BatchItemResult<T>  { id: EmailId, data?: T, error?: { code, message } }
   MoveResult        { fromMailbox, toMailbox, targetId? }
@@ -145,6 +146,7 @@ AddLabelsBatchResult  { items: AddLabelsItem[] }
 | Tool | Input | Output | IMAP Op |
 |---|---|---|---|
 | `get_folders` | — | `FolderInfo[]` | LIST * + STATUS (messages, unseen, uidNext) |
+| `create_folder` | `path` | `CreateFolderResult` | CREATE mailbox |
 | `list_mailbox` | `mailbox`, `limit`, `offset` | `EmailSummary[]` | SELECT + FETCH seq range, reversed |
 | `fetch_summaries` | `ids: EmailId[]` | `EmailSummary[]` | UID FETCH envelope+flags |
 | `fetch_message` | `ids: EmailId[]` | `EmailMessage[]` | UID FETCH source → mailparser |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `add_labels` MCP tool — add one or more Proton Mail labels to a batch of emails via IMAP COPY; returns per-email results including new UIDs in label folders
 - `AddLabelsBatchResult`, `AddLabelsItem`, `AddLabelsItemData` types in `src/types/operations.ts`
+- `create_folder` MCP tool — creates new mail folders under `Folders/` with recursive nested path support (e.g. `Folders/Work/Projects`); returns whether the folder was newly created or already existed
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ import { ImapClient } from './bridge/imap';      // ✗ fails at runtime
 | Tool | Purpose |
 |---|---|
 | `get_folders` | List all mail folders with message counts, unread counts, and IMAP metadata (excludes Proton labels) |
+| `create_folder` | Create a new mail folder under `Folders/` (recursive) |
 | `list_mailbox` | Browse emails in a mailbox, newest first (paginated) |
 | `fetch_summaries` | Envelope data for known UIDs (batch) |
 | `fetch_message` | Text/HTML body + attachment metadata (batch, no content) |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ An [MCP](https://modelcontextprotocol.io/) server that bridges ProtonMail to AI 
 
 ## Features
 
-- **12 MCP tools** for reading, searching, and organizing email
+- **13 MCP tools** for reading, searching, and organizing email
 - **Three transport modes** — STDIO, HTTP, and HTTPS
 - **IMAP connection pooling** with configurable min/max connections and idle drain timers
 - **Batch operations** with input-order stability and per-item error reporting
@@ -234,13 +234,14 @@ All environment variables use the `PROTONMAIL_` prefix. You can set them in a `.
 
 ## MCP Tools
 
-The server exposes 12 tools that MCP clients can call. Each tool is annotated with `readOnlyHint` or `destructiveHint` so clients can present appropriate confirmation prompts.
+The server exposes 13 tools that MCP clients can call. Each tool is annotated with `readOnlyHint` or `destructiveHint` so clients can present appropriate confirmation prompts.
 
 For **full documentation** — including input schemas, return types, and example JSON — see the **[Tools Reference](docs/tools/README.md)**.
 
 | Tool | Flags | Description |
 |---|---|---|
 | `get_folders` | read-only | List all mail folders with message counts, unread counts, and IMAP metadata (excludes Proton labels) |
+| `create_folder` | mutating | Create a new mail folder under `Folders/` (supports nested paths) |
 | `list_mailbox` | read-only | Browse emails in a mailbox, newest first, with pagination |
 | `fetch_summaries` | read-only | Fetch envelope data (from, to, subject, date, flags) for known email IDs |
 | `fetch_message` | read-only | Fetch full message body (text/HTML) and attachment metadata |

--- a/docs/plans/m3-folders-labels-revert.md
+++ b/docs/plans/m3-folders-labels-revert.md
@@ -13,7 +13,7 @@ of `delete_folder`, which clears the log.
 
 | Topic | Decision |
 |---|---|
-| Folder name shape | Multi-segment names allowed (e.g. `Work/Projects`). Optional `parent` param, defaults to `Folders/`; must be rooted in `Folders/`. |
+| Folder path shape | Single `path` parameter (must start with `Folders/`). Multi-segment paths allowed (e.g. `Folders/Work/Projects`). IMAP CREATE handles recursive creation. |
 | IMAP CREATE API | Confirmed: `conn.mailboxCreate(path)` → `{ path, created: boolean }` |
 | IMAP DELETE API | Confirmed: `conn.mailboxDelete(path)` → `{ path }` |
 | `delete_folder` | Clears the operation log via new `@Irreversible` decorator. NOT @Tracked. |
@@ -109,37 +109,37 @@ Array<{
 
 ## Issue 2 — `M3: create_folder — create a custom mail folder`
 
-**Goal:** Create user-defined mail folders, supporting nested paths and a configurable parent.
+**Goal:** Create user-defined mail folders, supporting nested paths.
 
 ### Tool specification
 
 **Name:** `create_folder`
 
 **Description:**
-> Create a new mail folder. The name may include path separators for nesting (e.g.
-> 'Work/Projects'). The optional parent defaults to 'Folders/' and must itself be rooted in
-> Folders/. Returns the full path of the created folder and whether it was newly created or
-> already existed.
+> Create a new mail folder. The path must start with 'Folders/' and include at least one
+> folder name segment (e.g. 'Folders/Work' or 'Folders/Work/Projects'). Nested paths are
+> created recursively by IMAP CREATE. Returns the full path and whether it was newly created
+> or already existed.
 
 **Parameters:**
 ```typescript
 {
-  name:    string;  // Required. Folder name; may contain "/" for nesting.
-  parent?: string;  // Optional. Default: "Folders/". Must start with "Folders/".
+  path: string;  // Required. Full folder path, must start with "Folders/".
+                 // Nested segments (e.g. "Folders/Work/Projects") created recursively.
 }
 ```
 
 **Return:**
 ```typescript
 {
-  operationId: number;  // For use with revert_operations
-  path:        string;  // Full path, e.g. "Folders/Work/Projects"
-  created:     boolean; // true = newly created; false = already existed (no error)
+  path:    string;  // Full path, e.g. "Folders/Work/Projects"
+  created: boolean; // true = newly created; false = already existed (no error)
 }
 ```
+_(Note: `operationId` will be added when the operation log interceptor is implemented in Issue 9.)_
 
 **Error conditions:**
-- `FORBIDDEN` — `parent` does not start with `"Folders/"`, or resolves to a protected path
+- `INVALID_PATH` — path does not start with `"Folders/"`, is bare `"Folders/"`, or has no folder name after the prefix
 - IMAP failure → top-level thrown error
 
 ### imapflow API
@@ -148,8 +148,8 @@ Array<{
 
 ### Implementation steps
 
-1. Add `src/tools/create-folder.ts` with Zod schema as above. Validate `parent` in handler.
-   Construct path: `parent.replace(/\/$/, '') + '/' + name`.
+1. Add `src/tools/create-folder.ts` with Zod schema for `path`. Validate path starts with
+   `Folders/` and contains a folder name after the prefix.
 2. Add `ImapClient.createFolder(path: string): Promise<CreateFolderResult>` with `@Audited('create_folder')`.
 3. On `OperationLogInterceptor`: wrap `createFolder` with `@Tracked`, reversal
    `{ type: 'create_folder', path }`. Revert = `deleteFolder(path)`.
@@ -159,10 +159,10 @@ Array<{
 
 ### Acceptance criteria
 
-- `{ name: "Work" }` → `Folders/Work` appears in `get_folders`.
-- `{ name: "Work/Projects" }` → `Folders/Work/Projects` appears.
-- `{ name: "Deep", parent: "Folders/Work" }` → `Folders/Work/Deep` appears.
-- `parent: "INBOX"` → `FORBIDDEN`.
+- `{ path: "Folders/Work" }` → `Folders/Work` appears in `get_folders`.
+- `{ path: "Folders/Work/Projects" }` → `Folders/Work/Projects` appears (recursive creation).
+- `{ path: "Folders/" }` → `INVALID_PATH`.
+- `{ path: "INBOX" }` → `INVALID_PATH`.
 - Pre-existing path → `{ created: false }`, no error.
 
 ---

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -23,6 +23,7 @@ All batch operations preserve input order — `result[i]` always corresponds to 
   - [fetch_attachment](#fetch_attachment)
   - [search_mailbox](#search_mailbox)
 - [Write Operations](#write-operations)
+  - [create_folder](#create_folder)
   - [move_emails](#move_emails)
   - [mark_read](#mark_read)
   - [mark_unread](#mark_unread)
@@ -203,6 +204,35 @@ Search for emails in a mailbox by text query. Uses IMAP `TEXT` search, which mat
 ---
 
 ## Write Operations
+
+### `create_folder`
+
+Create a new mail folder under `Folders/`. Supports nested paths — intermediate folders are created recursively by IMAP CREATE. If the folder already exists, returns `created: false` without error.
+
+| | |
+|---|---|
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+
+**Input:**
+
+| Field | Type | Description |
+|---|---|---|
+| `path` | `string` | Full folder path (must start with `"Folders/"`). Nested segments (e.g. `"Folders/Work/Projects"`) are created recursively. |
+
+**Returns:** `CreateFolderResult`
+
+```jsonc
+{
+  "path": "Folders/Work/Projects",   // Full IMAP path of the folder
+  "created": true                    // true = newly created; false = already existed
+}
+```
+
+**Error conditions:**
+- `INVALID_PATH` — path does not start with `"Folders/"`, is bare `"Folders/"`, or is empty after stripping trailing slashes
+- IMAP failure -> top-level thrown error
+
+---
 
 ### `move_emails`
 

--- a/src/bridge/errors.ts
+++ b/src/bridge/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Detects whether an imapflow error indicates a mailbox already exists.
+ * Checks the RFC 5530 response code first, then falls back to text matching
+ * for servers (like Proton Bridge) that send bare NO responses.
+ */
+export function isAlreadyExistsError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { serverResponseCode?: string; responseText?: string; response?: string };
+  if (e.serverResponseCode === 'ALREADYEXISTS') return true;
+  const text = e.responseText || e.response || '';
+  return /already.?exists|mailbox exists/i.test(text);
+}

--- a/src/bridge/imap.ts
+++ b/src/bridge/imap.ts
@@ -1,5 +1,6 @@
 import { simpleParser } from 'mailparser';
 import type { ImapFlow, FetchMessageObject, MessageAddressObject, ListResponse } from 'imapflow';
+import { isAlreadyExistsError } from './errors.js';
 import { Audited } from './decorators.js';
 import type { AuditLogger } from './audit.js';
 import type { ImapConnectionPool } from './pool.js';
@@ -12,6 +13,7 @@ import type {
   AttachmentMetadata,
   AttachmentContent,
   FolderInfo,
+  CreateFolderResult,
   MoveBatchResult,
   FlagBatchResult,
   BatchItemResult,
@@ -47,6 +49,25 @@ export class ImapClient {
           !mb.path.startsWith('Labels/'),
         )
         .map(toFolderInfo);
+    } finally {
+      this.#pool.release(conn);
+    }
+  }
+
+  @Audited('create_folder')
+  async createFolder(path: string): Promise<CreateFolderResult> {
+    const conn = await this.#pool.acquire();
+    try {
+      const result = await conn.mailboxCreate(path);
+      return {
+        path:    result.path,
+        created: result.created,
+      };
+    } catch (err: unknown) {
+      if (isAlreadyExistsError(err)) {
+        return { path, created: false };
+      }
+      throw err;
     } finally {
       this.#pool.release(conn);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import type { ImapClient }         from './bridge/imap.js';
 import type { ImapConnectionPool } from './bridge/pool.js';
 import {
   getFoldersSchema,         handleGetFolders,
+  createFolderSchema,       handleCreateFolder,
   listMailboxSchema,        handleListMailbox,
   fetchSummariesSchema,     handleFetchSummaries,
   fetchMessageSchema,       handleFetchMessage,
@@ -46,6 +47,18 @@ export function createMcpServer(
     },
     async () => ({
       content: [{ type: 'text', text: toText(await handleGetFolders(imap)) }],
+    }),
+  );
+
+  server.registerTool(
+    'create_folder',
+    {
+      description: "Create a new mail folder at the given path. The path must start with 'Folders/' and may include nested segments (e.g. 'Folders/Work/Projects') which are created recursively. Returns the full path and whether it was newly created or already existed.",
+      inputSchema: createFolderSchema,
+      annotations: MUTATING,
+    },
+    async (args) => ({
+      content: [{ type: 'text', text: toText(await handleCreateFolder(args, imap)) }],
     }),
   );
 

--- a/src/tools/create-folder.ts
+++ b/src/tools/create-folder.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import type { ImapClient } from '../bridge/imap.js';
+import type { CreateFolderResult } from '../types/index.js';
+
+export const createFolderSchema = {
+  path: z.string().min(1)
+    .describe('Full folder path (must start with "Folders/"). Nested segments (e.g. "Folders/Work/Projects") are created recursively.'),
+};
+
+export async function handleCreateFolder(
+  args: { path: string },
+  imap: ImapClient,
+): Promise<CreateFolderResult> {
+  // Strip trailing slashes and validate a real folder name exists after "Folders/"
+  const cleaned = args.path.replace(/\/+$/, '');
+  if (!cleaned || cleaned === 'Folders' || !cleaned.startsWith('Folders/') || cleaned === 'Folders/') {
+    throw new Error('INVALID_PATH: path must contain a folder name after "Folders/" (e.g. "Folders/MyFolder")');
+  }
+  return imap.createFolder(cleaned);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 export * from './get-folders.js';
+export * from './create-folder.js';
 export * from './list-mailbox.js';
 export * from './fetch-summaries.js';
 export * from './fetch-message.js';

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -43,5 +43,11 @@ export interface AddLabelsBatchResult {
   items: AddLabelsItem[];
 }
 
+/** Result of a folder creation */
+export interface CreateFolderResult {
+  path:    string;
+  created: boolean;
+}
+
 export type MoveBatchResult = BatchItemResult<MoveResult>[];
 export type FlagBatchResult = BatchItemResult<FlagResult>[];


### PR DESCRIPTION
## Summary

- Adds `create_folder` MCP tool that creates new mail folders under `Folders/` via IMAP CREATE
- Supports recursive nested path creation (e.g. `Folders/Work/Projects`)
- Returns `{ path, created }` indicating whether the folder was newly created or already existed
- Includes shared `isAlreadyExistsError` helper in `src/bridge/errors.ts` for reuse across tools

Closes #14

## Test plan

- [ ] Creating a new folder (e.g. `Folders/TestFolder`) returns `{ path: "Folders/TestFolder", created: true }`
- [ ] Creating a folder that already exists returns `{ path: "Folders/TestFolder", created: false }`
- [ ] Passing `Folders/` alone (no folder name) returns `INVALID_PATH` error
- [ ] Nested paths like `Folders/Work/Projects` create intermediate folders recursively
- [ ] Path without `Folders/` prefix is rejected with `INVALID_PATH` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)