### PR TITLE
refactor: standardize tool result structures with status fields

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,33 +134,45 @@ FolderInfo extends MailboxBase  { path, delimiter }
 LabelInfo = MailboxBase
 CreateFolderResult  { path, created }
 
-BatchItemResult<T>  { id: EmailId, data?: T, error?: { code, message } }
+── Status & Wrapper Types ──
+
+ToolStatus          'succeeded' | 'partial' | 'failed'
+ItemStatus          'succeeded' | 'failed'
+
+BatchToolResult<T>  { status: ToolStatus, items: BatchItemResult<T>[] }
+ListToolResult<T>   { status: ToolStatus, items: T[] }
+SingleToolResult<T> { status: ToolStatus, data: T }
+
+batchStatus<T>(items)  utility → ToolStatus from per-item statuses
+
+── Batch Item Types ──
+
+BatchItemResult<T>  { id: EmailId, status: ItemStatus, data?: T, error?: { code, message } }
   MoveResult        { fromMailbox, toMailbox, targetId? }
   FlagResult        { flagsAfter: string[] }
 
-AddLabelsBatchResult  { items: AddLabelsItem[] }
-  AddLabelsItem       { id, data?: AddLabelsItemData[], error? }
-    AddLabelsItemData { labelPath, newId?: EmailId }
+AddLabelsBatchResult  = BatchToolResult<AddLabelsItemData[]>
+  AddLabelsItemData   { labelPath, newId?: EmailId }
 ```
 
 ## Tool Inventory
 
 | Tool | Input | Output | IMAP Op |
 |---|---|---|---|
-| `get_folders` | — | `FolderInfo[]` | LIST * + STATUS (messages, unseen, uidNext) |
-| `get_labels` | — | `LabelInfo[]` | LIST * + STATUS (messages, unseen, uidNext) |
-| `create_folder` | `path` | `CreateFolderResult` | CREATE mailbox |
-| `list_mailbox` | `mailbox`, `limit`, `offset` | `EmailSummary[]` | SELECT + FETCH seq range, reversed |
-| `fetch_summaries` | `ids: EmailId[]` | `EmailSummary[]` | UID FETCH envelope+flags |
-| `fetch_message` | `ids: EmailId[]` | `EmailMessage[]` | UID FETCH source → mailparser |
-| `fetch_attachment` | `id`, `partId` | `AttachmentContent` | UID FETCH source → mailparser attachment[partId-1] |
-| `search_mailbox` | `mailbox`, `query`, `limit`, `offset` | `EmailSummary[]` | SEARCH TEXT + UID FETCH |
-| `move_emails` | `ids`, `targetMailbox` | `MoveBatchResult` | UID MOVE per item |
-| `mark_read` | `ids` | `FlagBatchResult` | UID STORE +FLAGS (\\Seen) |
-| `mark_unread` | `ids` | `FlagBatchResult` | UID STORE -FLAGS (\\Seen) |
-| `verify_connectivity` | — | `{ success, latencyMs? }` | connect + NOOP |
+| `get_folders` | — | `ListToolResult<FolderInfo>` | LIST * + STATUS (messages, unseen, uidNext) |
+| `get_labels` | — | `ListToolResult<LabelInfo>` | LIST * + STATUS (messages, unseen, uidNext) |
+| `create_folder` | `path` | `SingleToolResult<CreateFolderResult>` | CREATE mailbox |
+| `list_mailbox` | `mailbox`, `limit`, `offset` | `ListToolResult<EmailSummary>` | SELECT + FETCH seq range, reversed |
+| `fetch_summaries` | `ids: EmailId[]` | `ListToolResult<EmailSummary>` | UID FETCH envelope+flags |
+| `fetch_message` | `ids: EmailId[]` | `ListToolResult<EmailMessage>` | UID FETCH source → mailparser |
+| `fetch_attachment` | `id`, `partId` | `SingleToolResult<AttachmentContent>` | UID FETCH source → mailparser attachment[partId-1] |
+| `search_mailbox` | `mailbox`, `query`, `limit`, `offset` | `ListToolResult<EmailSummary>` | SEARCH TEXT + UID FETCH |
+| `move_emails` | `ids`, `targetMailbox` | `BatchToolResult<MoveResult>` | UID MOVE per item |
+| `mark_read` | `ids` | `BatchToolResult<FlagResult>` | UID STORE +FLAGS (\\Seen) |
+| `mark_unread` | `ids` | `BatchToolResult<FlagResult>` | UID STORE -FLAGS (\\Seen) |
+| `verify_connectivity` | — | `SingleToolResult<{ latencyMs?, error? }>` | connect + NOOP |
 | `add_labels` | `ids`, `labelNames` | `AddLabelsBatchResult` | UID COPY per item/label |
-| `drain_connections` | — | `{ message }` | pool.drain() |
+| `drain_connections` | — | `SingleToolResult<{ message }>` | pool.drain() |
 
 ## Batch Contract
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `get_labels` MCP tool — list all Proton Mail labels with message counts, unread counts, and IMAP metadata; complements `get_folders` using a shared `#listMailboxes` helper
 - `add_labels` MCP tool — add one or more Proton Mail labels to a batch of emails via IMAP COPY; returns per-email results including new UIDs in label folders
-- `AddLabelsBatchResult`, `AddLabelsItem`, `AddLabelsItemData` types in `src/types/operations.ts`
+- `AddLabelsBatchResult`, `AddLabelsItemData` types in `src/types/operations.ts`
 - `create_folder` MCP tool — creates new mail folders under `Folders/` with recursive nested path support (e.g. `Folders/Work/Projects`); returns whether the folder was newly created or already existed
+- `ToolStatus`, `ItemStatus`, `BatchToolResult<T>`, `ListToolResult<T>`, `SingleToolResult<T>` types for standardized tool responses
+- `batchStatus()` utility to compute top-level status from per-item statuses
+- `status: ItemStatus` field on `BatchItemResult<T>` for per-item success/failure tracking
 
 ### Changed
 
 - Simplified the release
 - `get_folders` MCP tool replaces `list_folders` — enriched per-folder metadata (message count, unread count, UID next, listed/subscribed status) via inline STATUS query; filters out Proton labels (`Labels/`), the `Starred` virtual mailbox, and the `Labels` root
+- All tool handlers now return standardized wrapper types with top-level `status` field
+- `verify_connectivity` removes `success` boolean; uses `SingleToolResult` with `status: 'succeeded'/'failed'` and `data: { latencyMs?, error? }`
+- `drain_connections` reclassified from `READ_ONLY` to `DESTRUCTIVE` annotation
+- `AddLabelsItem` unified into `BatchItemResult<AddLabelsItemData[]>` (removed separate type)
 
 ## [0.2.0] - 2026-04-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,17 @@ Every public `ImapClient` method must be decorated with `@Audited('operation_nam
 Wraps the method in `this.audit.wrap()` — no manual audit calls needed in method bodies.
 The class must expose `audit: AuditLogger` as a public property (not private).
 
+### Standardized Tool Result Structure
+Every tool response includes a top-level `status: ToolStatus` (`'succeeded' | 'partial' | 'failed'`).
+Three wrapper types:
+- `BatchToolResult<T>` — batch-mutating tools: `{ status, items: BatchItemResult<T>[] }`
+- `ListToolResult<T>` — read-only array tools: `{ status, items: T[] }`
+- `SingleToolResult<T>` — single-item tools: `{ status, data: T }`
+
+Each `BatchItemResult<T>` also carries `status: ItemStatus` (`'succeeded' | 'failed'`).
+Use `batchStatus(items)` utility to compute the top-level status from per-item statuses.
+Read-only tools always return `status: 'succeeded'` (they throw on failure).
+
 ### Batch Operations + Index Stability
 All `ImapClient` methods taking `EmailId[]` preserve input order in results.
 `BatchItemResult<T>[]` ops: result[i] ↔ input[i], with success or `{ code, message }` error.

--- a/src/bridge/imap.ts
+++ b/src/bridge/imap.ts
@@ -23,9 +23,9 @@ import type {
   MoveResult,
   FlagResult,
   AddLabelsBatchResult,
-  AddLabelsItem,
   AddLabelsItemData,
 } from '../types/index.js';
+import { batchStatus } from '../types/index.js';
 
 export class ImapClient {
   readonly audit: AuditLogger;
@@ -252,7 +252,7 @@ export class ImapClient {
 
   @Audited('move_emails')
   async moveEmails(ids: EmailId[], targetMailbox: string): Promise<MoveBatchResult> {
-    const results: Array<BatchItemResult<MoveResult>> = ids.map(id => ({ id }));
+    const results: Array<BatchItemResult<MoveResult>> = ids.map(id => ({ id, status: 'failed' as const }));
 
     // Group by source mailbox
     const groups = groupByMailbox(ids);
@@ -268,6 +268,7 @@ export class ImapClient {
             const targetUid = moved !== false ? moved.uidMap?.get(id.uid) : undefined;
             results[index] = {
               id,
+              status: 'succeeded',
               data: {
                 fromMailbox: mailbox,
                 toMailbox:   targetMailbox,
@@ -277,6 +278,7 @@ export class ImapClient {
           } catch (err) {
             results[index] = {
               id,
+              status: 'failed',
               error: { code: 'MOVE_FAILED', message: err instanceof Error ? err.message : String(err) },
             };
           }
@@ -292,7 +294,7 @@ export class ImapClient {
 
   @Audited('set_flag')
   async setFlag(ids: EmailId[], flag: string, add: boolean): Promise<FlagBatchResult> {
-    const results: Array<BatchItemResult<FlagResult>> = ids.map(id => ({ id }));
+    const results: Array<BatchItemResult<FlagResult>> = ids.map(id => ({ id, status: 'failed' as const }));
     const groups = groupByMailbox(ids);
 
     for (const { mailbox, entries } of groups) {
@@ -311,10 +313,11 @@ export class ImapClient {
             for await (const msg of conn.fetch(String(id.uid), { uid: true, flags: true }, { uid: true })) {
               flagsAfter.push(...(msg.flags ? [...msg.flags] : []));
             }
-            results[index] = { id, data: { flagsAfter } };
+            results[index] = { id, status: 'succeeded', data: { flagsAfter } };
           } catch (err) {
             results[index] = {
               id,
+              status: 'failed',
               error: { code: 'FLAG_FAILED', message: err instanceof Error ? err.message : String(err) },
             };
           }
@@ -331,7 +334,7 @@ export class ImapClient {
   @Audited('add_labels')
   async addLabels(ids: EmailId[], labelNames: string[]): Promise<AddLabelsBatchResult> {
     const labelPaths = labelNames.map(name => `Labels/${name}`);
-    const items: AddLabelsItem[] = ids.map(id => ({ id }));
+    const items: Array<BatchItemResult<AddLabelsItemData[]>> = ids.map(id => ({ id, status: 'failed' as const }));
     const groups = groupByMailbox(ids);
 
     const conn = await this.#pool.acquire();
@@ -358,9 +361,9 @@ export class ImapClient {
             }
 
             if (itemError) {
-              items[index] = { id, error: itemError };
+              items[index] = { id, status: 'failed', error: itemError };
             } else {
-              items[index] = { id, data: labelResults };
+              items[index] = { id, status: 'succeeded', data: labelResults };
             }
           }
         } finally {
@@ -371,7 +374,7 @@ export class ImapClient {
       this.#pool.release(conn);
     }
 
-    return { items };
+    return { status: batchStatus(items), items };
   }
 
   /** Shared helper: fetch per mailbox group, reorder to match input order */

--- a/src/server.ts
+++ b/src/server.ts
@@ -176,7 +176,7 @@ export function createMcpServer(
     {
       description: 'Close all connections in the IMAP connection pool immediately. Useful for forcing reconnection after a Proton Bridge restart.',
       inputSchema: drainConnectionsSchema,
-      annotations: READ_ONLY,
+      annotations: DESTRUCTIVE,
     },
     async () => ({
       content: [{ type: 'text', text: toText(await handleDrainConnections(pool)) }],

--- a/src/tools/add-labels.ts
+++ b/src/tools/add-labels.ts
@@ -18,5 +18,6 @@ export async function handleAddLabels(
   args: { ids: Array<{ uid: number; mailbox: string }>; labelNames: string[] },
   imap: ImapClient,
 ): Promise<AddLabelsBatchResult> {
+  // addLabels already returns BatchToolResult<AddLabelsItemData[]> with status
   return imap.addLabels(args.ids, args.labelNames);
 }

--- a/src/tools/create-folder.ts
+++ b/src/tools/create-folder.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { CreateFolderResult } from '../types/index.js';
+import type { SingleToolResult, CreateFolderResult } from '../types/index.js';
 
 export const createFolderSchema = {
   path: z.string().min(1)
@@ -10,11 +10,12 @@ export const createFolderSchema = {
 export async function handleCreateFolder(
   args: { path: string },
   imap: ImapClient,
-): Promise<CreateFolderResult> {
+): Promise<SingleToolResult<CreateFolderResult>> {
   // Strip trailing slashes and validate a real folder name exists after "Folders/"
   const cleaned = args.path.replace(/\/+$/, '');
   if (!cleaned || cleaned === 'Folders' || !cleaned.startsWith('Folders/') || cleaned === 'Folders/') {
     throw new Error('INVALID_PATH: path must contain a folder name after "Folders/" (e.g. "Folders/MyFolder")');
   }
-  return imap.createFolder(cleaned);
+  const data = await imap.createFolder(cleaned);
+  return { status: 'succeeded' as const, data };
 }

--- a/src/tools/drain-connections.ts
+++ b/src/tools/drain-connections.ts
@@ -1,10 +1,11 @@
 import type { ImapConnectionPool } from '../bridge/pool.js';
+import type { SingleToolResult } from '../types/index.js';
 
 export const drainConnectionsSchema = {};
 
 export async function handleDrainConnections(
   pool: ImapConnectionPool,
-): Promise<{ message: string }> {
+): Promise<SingleToolResult<{ message: string }>> {
   await pool.drain();
-  return { message: 'Connection pool drained. New connections will be created on next request.' };
+  return { status: 'succeeded' as const, data: { message: 'Connection pool drained. New connections will be created on next request.' } };
 }

--- a/src/tools/fetch-attachment.ts
+++ b/src/tools/fetch-attachment.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { AttachmentContent } from '../types/index.js';
+import type { SingleToolResult, AttachmentContent } from '../types/index.js';
 
 export const fetchAttachmentSchema = {
   id: z.object({
@@ -14,6 +14,7 @@ export const fetchAttachmentSchema = {
 export async function handleFetchAttachment(
   args: { id: { uid: number; mailbox: string }; partId: string },
   imap: ImapClient,
-): Promise<AttachmentContent> {
-  return imap.fetchAttachment(args.id, args.partId);
+): Promise<SingleToolResult<AttachmentContent>> {
+  const data = await imap.fetchAttachment(args.id, args.partId);
+  return { status: 'succeeded' as const, data };
 }

--- a/src/tools/fetch-message.ts
+++ b/src/tools/fetch-message.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { EmailMessage } from '../types/index.js';
+import type { ListToolResult, EmailMessage } from '../types/index.js';
 
 const emailIdSchema = z.object({
   uid:     z.number().int().positive().describe('IMAP UID'),
@@ -15,6 +15,7 @@ export const fetchMessageSchema = {
 export async function handleFetchMessage(
   args: { ids: Array<{ uid: number; mailbox: string }> },
   imap: ImapClient,
-): Promise<EmailMessage[]> {
-  return imap.fetchMessage(args.ids);
+): Promise<ListToolResult<EmailMessage>> {
+  const items = await imap.fetchMessage(args.ids);
+  return { status: 'succeeded' as const, items };
 }

--- a/src/tools/fetch-summaries.ts
+++ b/src/tools/fetch-summaries.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { EmailSummary } from '../types/index.js';
+import type { ListToolResult, EmailSummary } from '../types/index.js';
 
 const emailIdSchema = z.object({
   uid:     z.number().int().positive().describe('IMAP UID'),
@@ -14,6 +14,7 @@ export const fetchSummariesSchema = {
 export async function handleFetchSummaries(
   args: { ids: Array<{ uid: number; mailbox: string }> },
   imap: ImapClient,
-): Promise<EmailSummary[]> {
-  return imap.fetchSummaries(args.ids);
+): Promise<ListToolResult<EmailSummary>> {
+  const items = await imap.fetchSummaries(args.ids);
+  return { status: 'succeeded' as const, items };
 }

--- a/src/tools/get-folders.ts
+++ b/src/tools/get-folders.ts
@@ -1,10 +1,11 @@
 import type { ImapClient } from '../bridge/imap.js';
-import type { FolderInfo } from '../types/index.js';
+import type { ListToolResult, FolderInfo } from '../types/index.js';
 
 export const getFoldersSchema = {};
 
 export async function handleGetFolders(
   imap: ImapClient,
-): Promise<FolderInfo[]> {
-  return imap.getFolders();
+): Promise<ListToolResult<FolderInfo>> {
+  const items = await imap.getFolders();
+  return { status: 'succeeded' as const, items };
 }

--- a/src/tools/list-mailbox.ts
+++ b/src/tools/list-mailbox.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { EmailSummary } from '../types/index.js';
+import type { ListToolResult, EmailSummary } from '../types/index.js';
 
 export const listMailboxSchema = {
   mailbox: z.string().min(1).default('INBOX').describe('Mailbox name (e.g. INBOX, Sent, Trash)'),
@@ -11,6 +11,7 @@ export const listMailboxSchema = {
 export async function handleListMailbox(
   args:  { mailbox: string; limit: number; offset: number },
   imap:  ImapClient,
-): Promise<EmailSummary[]> {
-  return imap.listMailbox(args.mailbox, args.limit, args.offset);
+): Promise<ListToolResult<EmailSummary>> {
+  const items = await imap.listMailbox(args.mailbox, args.limit, args.offset);
+  return { status: 'succeeded' as const, items };
 }

--- a/src/tools/mark-read.ts
+++ b/src/tools/mark-read.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { FlagBatchResult } from '../types/index.js';
+import type { BatchToolResult, FlagResult } from '../types/index.js';
+import { batchStatus } from '../types/index.js';
 
 const emailIdSchema = z.object({
   uid:     z.number().int().positive().describe('IMAP UID'),
@@ -15,6 +16,7 @@ export const markReadSchema = {
 export async function handleMarkRead(
   args: { ids: Array<{ uid: number; mailbox: string }> },
   imap: ImapClient,
-): Promise<FlagBatchResult> {
-  return imap.setFlag(args.ids, '\\Seen', true);
+): Promise<BatchToolResult<FlagResult>> {
+  const items = await imap.setFlag(args.ids, '\\Seen', true);
+  return { status: batchStatus(items), items };
 }

--- a/src/tools/mark-unread.ts
+++ b/src/tools/mark-unread.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { FlagBatchResult } from '../types/index.js';
+import type { BatchToolResult, FlagResult } from '../types/index.js';
+import { batchStatus } from '../types/index.js';
 
 const emailIdSchema = z.object({
   uid:     z.number().int().positive().describe('IMAP UID'),
@@ -15,6 +16,7 @@ export const markUnreadSchema = {
 export async function handleMarkUnread(
   args: { ids: Array<{ uid: number; mailbox: string }> },
   imap: ImapClient,
-): Promise<FlagBatchResult> {
-  return imap.setFlag(args.ids, '\\Seen', false);
+): Promise<BatchToolResult<FlagResult>> {
+  const items = await imap.setFlag(args.ids, '\\Seen', false);
+  return { status: batchStatus(items), items };
 }

--- a/src/tools/move-emails.ts
+++ b/src/tools/move-emails.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { MoveBatchResult } from '../types/index.js';
+import type { BatchToolResult, MoveResult } from '../types/index.js';
+import { batchStatus } from '../types/index.js';
 
 const emailIdSchema = z.object({
   uid:     z.number().int().positive().describe('IMAP UID'),
@@ -17,6 +18,7 @@ export const moveEmailsSchema = {
 export async function handleMoveEmails(
   args: { ids: Array<{ uid: number; mailbox: string }>; targetMailbox: string },
   imap: ImapClient,
-): Promise<MoveBatchResult> {
-  return imap.moveEmails(args.ids, args.targetMailbox);
+): Promise<BatchToolResult<MoveResult>> {
+  const items = await imap.moveEmails(args.ids, args.targetMailbox);
+  return { status: batchStatus(items), items };
 }

--- a/src/tools/search-mailbox.ts
+++ b/src/tools/search-mailbox.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ImapClient } from '../bridge/imap.js';
-import type { EmailSummary } from '../types/index.js';
+import type { ListToolResult, EmailSummary } from '../types/index.js';
 
 export const searchMailboxSchema = {
   mailbox: z.string().min(1).default('INBOX').describe('Mailbox to search in'),
@@ -12,6 +12,7 @@ export const searchMailboxSchema = {
 export async function handleSearchMailbox(
   args: { mailbox: string; query: string; limit: number; offset: number },
   imap: ImapClient,
-): Promise<EmailSummary[]> {
-  return imap.searchMailbox(args.mailbox, args.query, args.limit, args.offset);
+): Promise<ListToolResult<EmailSummary>> {
+  const items = await imap.searchMailbox(args.mailbox, args.query, args.limit, args.offset);
+  return { status: 'succeeded' as const, items };
 }

--- a/src/tools/verify-connectivity.ts
+++ b/src/tools/verify-connectivity.ts
@@ -1,9 +1,15 @@
 import type { ImapConnectionPool } from '../bridge/pool.js';
+import type { SingleToolResult, ToolStatus } from '../types/index.js';
 
 export const verifyConnectivitySchema = {};
 
 export async function handleVerifyConnectivity(
   pool: ImapConnectionPool,
-): Promise<{ success: boolean; latencyMs?: number; error?: string }> {
-  return pool.verifyConnectivity();
+): Promise<SingleToolResult<{ latencyMs?: number; error?: string }>> {
+  const result = await pool.verifyConnectivity();
+  const status: ToolStatus = result.success ? 'succeeded' : 'failed';
+  if (result.success) {
+    return { status, data: { latencyMs: result.latencyMs } };
+  }
+  return { status, data: { error: result.error } };
 }

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -1,5 +1,35 @@
 import type { EmailId } from './email.js';
 
+// ── Status types ───────────────────────────────────────────────────────────────
+
+/** Top-level status for every tool response. */
+export type ToolStatus = 'succeeded' | 'partial' | 'failed';
+
+/** Per-item status inside batch results. */
+export type ItemStatus = 'succeeded' | 'failed';
+
+// ── Wrapper result types ───────────────────────────────────────────────────────
+
+/** Wrapper for batch-mutating tool results. */
+export interface BatchToolResult<T> {
+  status: ToolStatus;
+  items:  BatchItemResult<T>[];
+}
+
+/** Wrapper for read-only tools that return arrays. */
+export interface ListToolResult<T> {
+  status: ToolStatus;
+  items:  T[];
+}
+
+/** Wrapper for single-item tool results. */
+export interface SingleToolResult<T> {
+  status: ToolStatus;
+  data:   T;
+}
+
+// ── Batch item types ───────────────────────────────────────────────────────────
+
 /** Shared error shape for per-item batch failures. */
 export interface BatchItemError {
   code:    string;
@@ -12,8 +42,20 @@ export interface BatchItemError {
  */
 export interface BatchItemResult<T> {
   id:     EmailId;
+  status: ItemStatus;
   data?:  T;
   error?: BatchItemError;
+}
+
+// ── Utilities ──────────────────────────────────────────────────────────────────
+
+/** Compute top-level status from per-item statuses. */
+export function batchStatus<T>(items: BatchItemResult<T>[]): ToolStatus {
+  if (items.length === 0) return 'succeeded';
+  const failed = items.filter(i => i.status === 'failed').length;
+  if (failed === 0) return 'succeeded';
+  if (failed === items.length) return 'failed';
+  return 'partial';
 }
 
 /** Result of a single email move */
@@ -37,17 +79,8 @@ export interface AddLabelsItemData {
   newId?:    EmailId;
 }
 
-/** Per-email result for add_labels */
-export interface AddLabelsItem {
-  id:     EmailId;
-  data?:  AddLabelsItemData[];
-  error?: BatchItemError;
-}
-
-/** Batch result for add_labels */
-export interface AddLabelsBatchResult {
-  items: AddLabelsItem[];
-}
+/** Batch result for add_labels — unified with BatchItemResult */
+export type AddLabelsBatchResult = BatchToolResult<AddLabelsItemData[]>;
 
 /** Result of a folder creation */
 export interface CreateFolderResult {


### PR DESCRIPTION
## Summary
- Every tool response now includes top-level `status: ToolStatus` (`'succeeded' | 'partial' | 'failed'`)
- Batch operations include per-item `status: ItemStatus` (`'succeeded' | 'failed'`)
- New types: `BatchToolResult<T>`, `ListToolResult<T>`, `SingleToolResult<T>`, `batchStatus()` utility
- `verify_connectivity` drops `success` boolean, surfaces error in `data`
- `drain_connections` reclassified from `READ_ONLY` to `DESTRUCTIVE`

## Test plan
- [x] `verify_connectivity` → `{ status: 'succeeded', data: { latencyMs } }`, no `success` boolean
- [x] `drain_connections` → `{ status: 'succeeded', data: { message } }`
- [x] `get_folders` → `{ status: 'succeeded', items: [...] }`
- [x] `create_folder` → `{ status: 'succeeded', data: { path, created } }`
- [x] `mark_read` → batch wrapper with per-item status
- [x] `move_emails` → batch wrapper with per-item status

🤖 Generated with [Claude Code](https://claude.com/claude-code)