### PR TITLE
feat: add openWorldHint annotations to all tools (#42)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-proton-bridge-mcp is an MCP server that bridges ProtonMail to AI agents via the local Proton Bridge IMAP daemon. It exposes 16 tools for reading, searching, and organizing email through the Model Context Protocol. Three transport modes are supported: STDIO (default), HTTP, and HTTPS.
+proton-bridge-mcp is an MCP server that bridges ProtonMail to AI agents via the local Proton Bridge IMAP daemon. It exposes 18 tools for reading, searching, and organizing email through the Model Context Protocol. Three transport modes are supported: STDIO (default), HTTP, and HTTPS.
 
 ## Startup Flow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `openWorldHint` annotations on all 18 tools — signals whether a tool interacts with external entities. Most tools are `openWorldHint: true` (email data from external senders). Maintenance tools (`verify_connectivity`, `drain_connections`) are `openWorldHint: false` (local pool ops only). New `MAINTENANCE` annotation preset. (#42)
+- Fix: `drain_connections` annotation changed from `DESTRUCTIVE` to `MAINTENANCE` (was incorrectly marked destructive)
 - `remove_labels` MCP tool — bulk-remove Proton Mail labels from emails. Uses IMAP `messageDelete()` from label folders, which Proton Bridge translates to `UnlabelMessages()` (no permanent deletion). Finds copies by Message-ID search. Tracked via `@Tracked` — revertable with `revert_operations` (re-applies labels via `addLabels`). Annotated as DESTRUCTIVE. (#20)
 - `delete_label` MCP tool — delete Proton Mail labels by name. Irreversible (`@IrreversibleWhen`) — clears the operation log only when the label was actually deleted. Idempotent: returns `{ deleted: false }` for non-existent labels. Verified safe in Proton Bridge source — emails are preserved. (#18)
 - `create_label` reversal enabled — `revert_operations` can now undo `create_label` by calling `deleteLabel` (#18)
@@ -53,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2026-04-04
 
 ### Added
+
+- `openWorldHint` annotations on all 18 tools — signals whether a tool interacts with external entities. Most tools are `openWorldHint: true` (email data from external senders). Maintenance tools (`verify_connectivity`, `drain_connections`) are `openWorldHint: false` (local pool ops only). New `MAINTENANCE` annotation preset. (#42)
+- Fix: `drain_connections` annotation changed from `DESTRUCTIVE` to `MAINTENANCE` (was incorrectly marked destructive)
 
 - Release workflow attaches `proton-bridge-mcp.mcpb` and source archive (`proton-bridge-mcp-X.Y.Z-source.tar.gz`) to GitHub Releases
 - npm publish on release via `NPM_TOKEN` secret; `package.json` `files` field limits tarball to `dist/`, `manifest.json`, `CHANGELOG.md`, and `LICENSE`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Tools belong to one of four categories (used by `--disabled-tools` and for annot
 | **read** | `READ_ONLY` | `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`, `fetch_message`, `fetch_attachment`, `search_mailbox` |
 | **mutating** | `MUTATING` | `create_folder`, `create_label`, `mark_read`, `mark_unread`, `add_labels` |
 | **destructive** | `DESTRUCTIVE` | `move_emails`, `remove_labels`, `delete_folder`, `delete_label`, `revert_operations` |
-| **maintenance** | `READ_ONLY` | `verify_connectivity`, `drain_connections` |
+| **maintenance** | `MAINTENANCE` | `verify_connectivity`, `drain_connections` |
 
 - **Maintenance** tools are idempotent, non-destructive operations on the IMAP connection pool — they do not affect the Proton Mail inbox. See `src/tools/verify-connectivity.ts` and `src/tools/drain-connections.ts`.
 - When adding a new tool, assign it to the appropriate category and update `TOOL_CATEGORIES` in the source.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ All environment variables use the `PROTONMAIL_` prefix. You can set them in a `.
 
 ## MCP Tools
 
-The server exposes 16 tools that MCP clients can call. Each tool is annotated with `readOnlyHint` or `destructiveHint` so clients can present appropriate confirmation prompts.
+The server exposes 18 tools that MCP clients can call. Each tool is annotated with `readOnlyHint`, `destructiveHint`, and `openWorldHint` so clients can present appropriate confirmation prompts and trust boundary warnings.
 
 For **full documentation** — including input schemas, return types, and example JSON — see the **[Tools Reference](docs/tools/README.md)**.
 

--- a/docs/impl/mcp-tool-interfaces.md
+++ b/docs/impl/mcp-tool-interfaces.md
@@ -92,9 +92,11 @@ The `partial` status is critical for LLM consumption: it tells the agent that so
 Every tool declares `annotations` with boolean hints for mutability, destructiveness, and open-world classification. Three presets are defined in `src/server.ts`:
 
 ```typescript
-const READ_ONLY   = { readOnlyHint: true,  destructiveHint: false };
-const MUTATING    = { readOnlyHint: false, destructiveHint: false };
-const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true  };
+const READ_ONLY    = { readOnlyHint: true,  destructiveHint: false, openWorldHint: true  };
+const MUTATING     = { readOnlyHint: false, destructiveHint: false, openWorldHint: true  };
+const DESTRUCTIVE  = { readOnlyHint: false, destructiveHint: true,  openWorldHint: true  };
+const MAINTENANCE  = { readOnlyHint: true,  destructiveHint: false, openWorldHint: false };
+
 ```
 
 ### Mutability Classification
@@ -103,13 +105,16 @@ const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true  };
 
 **MUTATING** — The tool modifies state but the change is **reversible**. It can be undone via `revert_operations` or repeated application is harmless. Examples: flag changes (mark_read, mark_unread), label additions (add_labels), folder creation (create_folder). The LLM should confirm intent with the user before calling, but mistakes are recoverable.
 
-**DESTRUCTIVE** — The tool modifies state in a way that may be **irreversible** or has significant side effects. Examples: moving emails (source UID is invalidated, new UID may be unknown), draining connections (drops active pool state), reverting operations (applies cascading reverse changes). The LLM should exercise extra caution and clearly confirm with the user.
+**DESTRUCTIVE** — The tool modifies state in a way that may be **irreversible** or has significant side effects. Examples: moving emails (source UID is invalidated, new UID may be unknown), reverting operations (applies cascading reverse changes). The LLM should exercise extra caution and clearly confirm with the user.
+
+**MAINTENANCE** — The tool operates on local infrastructure (connection pool, daemon health) with no external data in responses. `openWorldHint: false` — no trust boundary crossed. `readOnlyHint: true` — does not modify email state. Examples: verify_connectivity, drain_connections.
 
 ### Mutability Guidelines for New Tools
 
 1. If it only reads data → `READ_ONLY`
 2. If it changes state but can be cleanly undone → `MUTATING`
 3. If it changes state and may be hard or impossible to undo, or has cascading effects → `DESTRUCTIVE`
+5. If it operates on local infrastructure only (pool, daemon) → `MAINTENANCE`
 4. **When in doubt, prefer DESTRUCTIVE** — it's safer for the LLM to treat an operation as destructive than to underestimate risk
 
 ### Open World Classification

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -48,7 +48,7 @@ List all mail folders with detailed metadata — message counts, unread counts, 
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 | **Input** | _(none)_ |
 
 **Returns:** `FolderInfo[]`
@@ -89,7 +89,7 @@ List all Proton Mail labels with detailed metadata — message counts, unread co
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 | **Input** | _(none)_ |
 
 **Returns:** `LabelInfo[]`
@@ -125,7 +125,7 @@ List emails in a ProtonMail mailbox, newest first. Returns envelope summaries (n
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -145,7 +145,7 @@ Fetch envelope summaries for a list of known email IDs. Use this when you alread
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -163,7 +163,7 @@ Fetch full message content (text/HTML body + attachment metadata) for a list of 
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -199,7 +199,7 @@ Download a single email attachment by its IMAP part ID (obtained from `fetch_mes
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -229,7 +229,7 @@ Search for emails in a mailbox by text query. Uses IMAP `TEXT` search, which mat
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -252,7 +252,7 @@ Create a new mail folder under `Folders/`. Supports nested paths — intermediat
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -281,7 +281,7 @@ Create a new Proton Mail label. Labels are flat — names must not contain path 
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -310,7 +310,7 @@ Delete a Proton Mail label. The underlying emails remain in their original folde
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` &nbsp; `openWorldHint: true` |
 
 > **Destructive & Irreversible:** Deleting a label clears the entire operation log. No prior operations can be reverted afterward.
 
@@ -342,7 +342,7 @@ Delete a user-created mail folder. The path must be under `Folders/`. Protected 
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` &nbsp; `openWorldHint: true` |
 
 > **Destructive & Irreversible:** Deleting a folder clears the entire operation log. No prior operations can be reverted afterward.
 
@@ -374,7 +374,7 @@ Move a batch of emails to a target mailbox. Returns per-email results with sourc
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: true` &nbsp; `openWorldHint: true` |
 
 > **Destructive:** Moving an email changes its UID and mailbox. The original UID becomes invalid.
 
@@ -412,7 +412,7 @@ Mark a batch of emails as read by adding the `\Seen` IMAP flag.
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -441,7 +441,7 @@ Mark a batch of emails as unread by removing the `\Seen` IMAP flag.
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -461,7 +461,7 @@ Add one or more Proton Mail labels to a batch of emails. Each email is copied in
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: false` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: true` |
 
 **Input:**
 
@@ -555,7 +555,7 @@ Test the connection to the Proton Bridge IMAP server. Acquires a connection from
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: false` |
 | **Input** | _(none)_ |
 
 **Returns:**
@@ -584,7 +584,7 @@ Close all connections in the IMAP connection pool immediately. Useful for forcin
 
 | | |
 |---|---|
-| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` |
+| **Annotations** | `readOnlyHint: true` &nbsp; `destructiveHint: false` &nbsp; `openWorldHint: false` |
 | **Input** | _(none)_ |
 
 **Returns:**

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,9 +31,10 @@ function toText(data: unknown): string {
   }, 2);
 }
 
-const READ_ONLY   = { readOnlyHint: true,  destructiveHint: false } as const;
-const MUTATING    = { readOnlyHint: false, destructiveHint: false } as const;
-const DESTRUCTIVE = { readOnlyHint: false, destructiveHint: true  } as const;
+const READ_ONLY    = { readOnlyHint: true,  destructiveHint: false, openWorldHint: true  } as const;
+const MUTATING     = { readOnlyHint: false, destructiveHint: false, openWorldHint: true  } as const;
+const DESTRUCTIVE  = { readOnlyHint: false, destructiveHint: true,  openWorldHint: true  } as const;
+const MAINTENANCE  = { readOnlyHint: true,  destructiveHint: false, openWorldHint: false } as const;
 
 /**
  * Creates a new McpServer with all tools registered.
@@ -211,7 +212,7 @@ export function createMcpServer(
     {
       description: 'Test the connection to the Proton Bridge IMAP server. Returns success status and latency.',
       inputSchema: verifyConnectivitySchema,
-      annotations: READ_ONLY,
+      annotations: MAINTENANCE,
     },
     async () => ({
       content: [{ type: 'text', text: toText(await handleVerifyConnectivity(pool)) }],
@@ -223,7 +224,7 @@ export function createMcpServer(
     {
       description: 'Close all connections in the IMAP connection pool immediately. Useful for forcing reconnection after a Proton Bridge restart.',
       inputSchema: drainConnectionsSchema,
-      annotations: DESTRUCTIVE,
+      annotations: MAINTENANCE,
     },
     async () => ({
       content: [{ type: 'text', text: toText(await handleDrainConnections(pool)) }],


### PR DESCRIPTION
## Summary

- Add `openWorldHint` to all 18 tool annotations — signals whether a tool interacts with external entities (email data from outside senders)
- New `MAINTENANCE` annotation preset (`readOnlyHint: true`, `destructiveHint: false`, `openWorldHint: false`) for local-only tools
- Fix: `drain_connections` changed from `DESTRUCTIVE` to `MAINTENANCE` (was incorrectly marked destructive)
- 16 tools: `openWorldHint: true` (email content crosses trust boundary)
- 2 tools: `openWorldHint: false` (`verify_connectivity`, `drain_connections` — local pool ops only)

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean (annotations are type-checked against MCP SDK ToolAnnotations)
- [x] `npm test` — 134/134 pass (no logic changes)
- [ ] Smoke test: verify tools list shows openWorldHint in Inspector

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)