### PR TITLE
docs: add Go migration roadmap for proton-mcp

### DIFF
--- a/docs/go-migration-roadmap.md
+++ b/docs/go-migration-roadmap.md
@@ -1,0 +1,1701 @@
+# Go Migration Roadmap for `proton-mcp`
+
+> This document is a roadmap for migrating the proton-bridge-mcp TypeScript project to a new Go project called `proton-mcp`. It is **written for Claude as the executor** in the new repo. Read it cold, follow the phases in order, verify each phase before moving to the next.
+
+## Reference repos
+
+You will reference two existing repositories throughout this work:
+
+- **`~/Projects/proton-bridge-mcp`** — the TypeScript implementation being replaced. Use it as a reference for tool semantics, design decisions, test scenarios, and documentation patterns. Do not copy code; copy concepts.
+- **`~/Projects/proton-bridge`** — Proton's official Bridge, written in Go. It is the canonical example of how to use `go-proton-api` correctly. When in doubt about Go patterns or API usage, look here first.
+
+## Background reading (do this before Phase 0)
+
+Read these files in `~/Projects/proton-bridge-mcp` before starting. They contain context that this roadmap assumes you understand:
+
+1. [docs/proton/authentication-flows.md](proton/authentication-flows.md) — how Proton authenticates, what go-proton-api handles for you, and the TOTP/CAPTCHA discussion. The "Porting Evaluation" section explains why this migration is happening.
+2. [docs/proton/bridge-label-implementation.md](proton/bridge-label-implementation.md) — how Proton Bridge virtualizes labels as IMAP folders. This is the complexity the new server escapes by going direct to the API.
+3. [docs/impl/label-handling.md](impl/label-handling.md) — the rule that no virtualized path may leak into tool responses. Still applies in Go, but easier to honor because labels are native.
+4. [docs/impl/operation-log-revert.md](impl/operation-log-revert.md) — the operation log + revert design. You will reimplement this in Go in Phase 5.
+5. [docs/impl/mcp-tool-interfaces.md](impl/mcp-tool-interfaces.md) — tool result types (`SingleToolResult`, `BatchToolResult`, `ListToolResult`). Translate these to Go structs.
+
+## What this migration achieves
+
+The current TypeScript MCP server talks to ProtonMail through the Bridge IMAP daemon. This forces the server to deal with IMAP's virtualization of labels-as-folders, COPYUID resolution for label copies, Message-ID searches to find virtualized copies, UID rewriting during revert, and a connection pool. About a thousand lines of code exist solely to manage IMAP and undo its virtualization.
+
+The Go version eliminates IMAP entirely. It uses `go-proton-api` directly — the same library that Bridge uses internally. Labels become native label IDs. UIDs become stable MessageIDs. The connection pool disappears. The label devirtualization layer disappears. Authentication is handled by go-proton-api in a single function call.
+
+The end state is a single static Go binary that depends on no external runtime, talks directly to Proton's API, and exposes the same MCP tool surface as the TypeScript version (with two intentional changes documented below).
+
+## Recommendation: new repo, not fork
+
+Create a new GitHub repo named `proton-mcp`. Do not fork `proton-bridge-mcp`. Reasons:
+
+- Different language entirely — no source is reused, only concepts and documentation
+- The new server doesn't depend on Bridge, so dropping "bridge" from the name reflects reality
+- A fork carries npm/Node.js git history that's irrelevant to a Go project
+- The new module path is `github.com/grover/proton-mcp` — clean, no suffix
+- Forking implies incremental migration; this is a clean rewrite
+
+You will selectively copy documentation, design decisions, and assets from `~/Projects/proton-bridge-mcp` into the new repo. The old repo stays alive as the TypeScript implementation until Phase 9 cutover.
+
+## What to retain from the old repo
+
+### Documentation
+
+Copy these files into the new repo with minor edits where noted:
+
+| Source | Destination | Adaptation |
+|---|---|---|
+| `docs/proton/bridge-label-implementation.md` | Same path | None — historical reference |
+| `docs/proton/webclient-api-extraction.md` | Same path | Add a note: "Go path was chosen — see `authentication-flows.md`" |
+| `docs/proton/authentication-flows.md` | Same path | None — directly applicable |
+| `docs/impl/label-handling.md` | Same path | Update opening paragraph: labels are now native, not virtualized; the no-leak rule still applies but for different reasons (consistency with input format, not protecting against IMAP UID confusion) |
+| `docs/impl/operation-log-revert.md` | Same path | Translate code snippets from TypeScript to Go in Phase 5 |
+| `docs/impl/mcp-tool-interfaces.md` | Same path | Translate type examples to Go structs |
+| `docs/tools/README.md` | Same path | Will be updated per phase as tools land |
+
+### Documentation to drop entirely
+
+- `docs/IMAP.md` — no IMAP in the new server
+- `docs/bridge-repair/` — Bridge-specific reference content
+- `docs/plans/edd-*.md` and `docs/plans/prd-*.md` — TypeScript-specific implementation plans
+- `docs/ROADMAP.md` — replaced by this roadmap
+- `docs/visuals.md` — keep if it has branding info you want, drop otherwise
+
+### Conventions to port (new CLAUDE.md)
+
+The old `CLAUDE.md` defines project conventions and the orchestrator workflow. Most of it is language-agnostic and worth keeping. The Go-adapted version should retain:
+
+- Operation modes (STDIO is primary; HTTP/HTTPS comes in Phase 11)
+- Tool categories (`read`, `mutating`, `destructive`, `maintenance`) and annotation presets (`READ_ONLY`, `MUTATING`, `DESTRUCTIVE`)
+- Operation log + revert design summary
+- Interface segregation principle: tool handlers depend on interfaces, not concrete types
+- Branch policy: `{type}/{issue#}-{title}` where type ∈ `bug`, `feat`, `refactor`, `docs`
+- Concurrent agent safety guidance
+- The orchestrator/QE/SWE/Reviewer persona rotation
+- EDD/PRD format for non-trivial changes
+- Engineering principles (TDD, clean code, fail fast, no fallbacks)
+
+The Go-adapted version should drop or replace:
+
+- Pre-commit checklist: replace `npm install -> lint -> build -> npm ci` with `go mod tidy -> go vet ./... -> golangci-lint run -> go test ./... -> go build ./...`
+- TypeScript-specific notes (Zod, NodeNext ESM imports, ts-jest)
+- npm-related sections (releases via release-it, MCPB packaging via build-mcpb.sh)
+- Smoke test commands (replace with `go run ./cmd/smoketest`)
+
+### Design concepts to re-implement in Go
+
+These are patterns from the TypeScript code that should be reproduced in idiomatic Go. They are not files to copy — they are designs to translate:
+
+1. **Tool result types** — `SingleToolResult[T]`, `BatchToolResult[T]`, `ListToolResult[T]` with a `status` field. Use Go generics (Go 1.18+).
+2. **Tool categories and annotations** — same taxonomy
+3. **Operation log** — ring buffer, monotonic IDs, FIFO eviction at 100 entries, no persistence
+4. **Interface segregation** — `ReadOnlyMailOps` and `MutatingMailOps` become Go interfaces; tool handlers accept these as parameters
+5. **`LabelInfo` with name only** — never expose IMAP paths or label IDs; same rule as TypeScript version
+6. **`CreateLabelResult { Name, Created }`** — same shape, no path leakage
+7. **No-op detection** — mutating operations compare before/after state, do not generate reversal entries for no-ops
+8. **`--login` CLI subcommand** for first-run auth (TOTP only, no CAPTCHA, no two-password mode)
+9. **MCP elicitation** for in-protocol prompts when the client supports it
+10. **Encrypted session vault** — analogous to Bridge's `vault.enc`, stores `{ AuthUID, RefreshToken, KeyPass }`
+
+### Cross-cutting concerns: the Go "middleware" pattern
+
+The TypeScript code uses `@Audited`, `@Tracked`, and `@IrreversibleWhen` decorators. Go has no decorators. The equivalent pattern is **wrapper functions that take a closure and return a wrapped version with cross-cutting behavior added**.
+
+Pattern:
+
+```go
+// AuditLogger writes JSONL audit events
+type AuditLogger interface {
+    Log(entry AuditEntry)
+}
+
+// Audited wraps a function call with audit logging.
+// Generic over the return type T.
+func Audited[T any](logger AuditLogger, op string, input any, fn func() (T, error)) (T, error) {
+    start := time.Now()
+    result, err := fn()
+    logger.Log(AuditEntry{
+        Operation: op,
+        Input:     input,
+        Duration:  time.Since(start),
+        Error:     errString(err),
+    })
+    return result, err
+}
+
+// Usage in a method:
+func (c *ProtonClient) MoveEmails(ctx context.Context, ids []EmailID, target string) (BatchResult[MoveResult], error) {
+    return Audited(c.audit, "move_emails", map[string]any{"ids": ids, "target": target},
+        func() (BatchResult[MoveResult], error) {
+            // actual implementation
+            return c.doMoveEmails(ctx, ids, target)
+        })
+}
+```
+
+This is the Go-idiomatic equivalent of decorators. It's slightly more verbose than TypeScript decorators but explicit — there is no hidden behavior. The same pattern works for `Tracked` (records reversal in operation log) and `IrreversibleWhen` (conditionally clears the log).
+
+You will implement these helper functions in Phase 5 when the operation log lands.
+
+### Tool catalog
+
+Reuse the exact tool names and semantics from the TypeScript implementation, with two intentional changes:
+
+| Category | Tools |
+|---|---|
+| **read** | `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`, `fetch_message`, `fetch_attachment`, `search_mailbox` |
+| **mutating** | `create_folder`, `create_label`, `mark_read`, `mark_unread`, `add_labels` |
+| **destructive** | `move_emails`, `remove_labels`, `delete_folder`, `delete_label`, `revert_operations` |
+| **maintenance** | `verify_session` |
+
+**Change 1: `verify_connectivity` → `verify_session`.** The TypeScript tool tested IMAP connectivity by acquiring a connection from the pool and measuring round-trip latency. There is no IMAP pool in the Go version. The new `verify_session` instead:
+
+- Verifies the stored auth session is still valid (not expired or revoked)
+- Calls `client.GetUser()` as a lightweight authenticated round-trip
+- Returns the user's primary email and session expiry information
+- Lets agents check "is the connection working?" before attempting heavier operations
+
+The semantics are similar (health check), but the implementation is fundamentally different. The new name reflects this.
+
+**Change 2: `drain_connections` is dropped.** The TypeScript version drained the IMAP connection pool. There is no connection pool in the Go version — go-proton-api manages a single HTTP client internally. The maintenance category contains only `verify_session`.
+
+### Artwork to copy
+
+Copy these files from `~/Projects/proton-bridge-mcp/assets/` into `assets/` in the new repo. Same product, different implementation — keep the branding:
+
+- `icon.svg`
+- `small-icon.svg`
+- `logo.svg`
+- `icon-256.png`, `icon-64.png`, `icon-32.png`, `icon-16.png`
+
+### What to drop entirely
+
+- All TypeScript source under `src/`
+- `package.json`, `package-lock.json`, `node_modules/`
+- `tsconfig.json`, `tsconfig.test.json`, `jest.config.ts`
+- `eslint.config.js`, `.prettierrc`
+- `scripts/run_smoketest.sh`, `scripts/run_inspector.sh` (replaced by `go run ./cmd/smoketest`)
+- All TypeScript tests
+- `.release-it.json` (release-it is npm-based — replaced by `goreleaser`)
+
+### What to adapt, not drop
+
+- **`manifest.json`** — the MCPB format is a zip with a manifest. For the Go binary, the manifest references the compiled binary as the entrypoint instead of a Node.js script. Claude Desktop MCPB packaging is **retained** because it's the easiest install path for end users; only the manifest contents change. You will adapt this in Phase 2.
+
+---
+
+## Phase 0: Project Bootstrap
+
+**Goal:** A new GitHub repo with an empty Go project that builds and passes CI.
+
+### Tasks
+
+- [ ] Create a new GitHub repo `proton-mcp` (private initially; make public after Phase 2 release)
+- [ ] Clone it locally to `~/Projects/proton-mcp`
+- [ ] Run `go mod init github.com/grover/proton-mcp`
+- [ ] Add base dependencies:
+  ```bash
+  go get github.com/ProtonMail/go-proton-api
+  go get github.com/modelcontextprotocol/go-sdk/mcp
+  go get github.com/spf13/cobra
+  go get github.com/joho/godotenv
+  ```
+- [ ] Create the directory layout:
+  ```
+  proton-mcp/
+  ├── cmd/
+  │   └── proton-mcp/
+  │       └── main.go         # Cobra root command
+  ├── internal/
+  │   ├── auth/               # Phase 1: SRP login, vault, refresh
+  │   ├── proton/             # Phase 2: ProtonClient wrapper, rate limit
+  │   ├── mcp/                # Phase 2: MCP server, tool registration
+  │   ├── ops/                # Phase 5: operation log, reversal specs
+  │   ├── tools/              # Phase 4+: tool handlers
+  │   └── audit/              # Phase 2: audit logger
+  ├── assets/                 # Copied from old repo
+  ├── docs/                   # Copied selectively from old repo
+  ├── .github/
+  │   └── workflows/
+  │       ├── ci.yml          # vet + lint + test + build
+  │       └── release.yml     # goreleaser, added in Phase 2
+  ├── .golangci.yml           # Linter config
+  ├── go.mod
+  ├── go.sum
+  ├── LICENSE                 # GPL-3.0 (matches go-proton-api license)
+  ├── README.md               # Minimal stub for now
+  ├── CLAUDE.md               # Adapted from old repo
+  └── CHANGELOG.md            # Empty [Unreleased] section
+  ```
+- [ ] Copy `assets/` from old repo
+- [ ] Copy `LICENSE` (GPL-3.0) — must match go-proton-api's license, the project is already GPL-anchored
+- [ ] Write minimal `cmd/proton-mcp/main.go`:
+  ```go
+  package main
+
+  import (
+      "fmt"
+      "os"
+
+      "github.com/spf13/cobra"
+  )
+
+  var rootCmd = &cobra.Command{
+      Use:   "proton-mcp",
+      Short: "MCP server for ProtonMail via go-proton-api",
+  }
+
+  func main() {
+      if err := rootCmd.Execute(); err != nil {
+          fmt.Fprintln(os.Stderr, err)
+          os.Exit(1)
+      }
+  }
+  ```
+- [ ] Configure `.golangci.yml` with sensible defaults: `errcheck`, `gosimple`, `govet`, `ineffassign`, `staticcheck`, `unused`, `gofmt`, `goimports`, `revive`
+- [ ] Create `.github/workflows/ci.yml`:
+  ```yaml
+  name: CI
+  on: [push, pull_request]
+  jobs:
+    test:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-go@v5
+          with: { go-version: '1.22' }
+        - run: go mod download
+        - run: go vet ./...
+        - uses: golangci/golangci-lint-action@v6
+          with: { version: latest }
+        - run: go test ./...
+        - run: go build ./...
+  ```
+- [ ] Adapt `CLAUDE.md` from the old repo following the conventions list above
+- [ ] Initial `CHANGELOG.md` with empty `[Unreleased]` section
+- [ ] Initial `README.md` with project description and "under active development" warning
+
+### Build tooling decision: no Makefile
+
+Makefiles are not idiomatic for Go projects. Use the `go` command directly for everything:
+
+- `go build ./...` — build all packages
+- `go test ./...` — run all tests
+- `go vet ./...` — static analysis
+- `golangci-lint run` — comprehensive linting
+- `go run ./cmd/proton-mcp serve` — run the server in dev mode
+
+For complex multi-step tasks (smoke tests, releases), put the orchestration logic in a `cmd/<task>/main.go` file and invoke with `go run ./cmd/<task>`. This keeps everything in Go, avoids shell escaping, works cross-platform, and adds no dependencies.
+
+Examples in the new repo:
+- `cmd/proton-mcp/main.go` — the main binary (login + serve subcommands)
+- `cmd/smoketest/main.go` — smoke test harness (added in Phase 3)
+
+There is no `Makefile`. There are no shell scripts in `scripts/`. Every developer task runs through `go run` or `go test`.
+
+### Verification
+
+- [ ] `go build ./...` succeeds with no warnings
+- [ ] `go vet ./...` produces no output
+- [ ] `golangci-lint run` produces no findings
+- [ ] CI workflow runs and passes on push
+- [ ] `go run ./cmd/proton-mcp` prints help text
+- [ ] `git log --oneline` shows a clean initial commit + bootstrap commit
+
+### Commit
+
+```
+chore: bootstrap proton-mcp project structure
+
+Initial Go module, directory layout, CI workflow, and adapted CLAUDE.md.
+Assets and core docs copied from proton-bridge-mcp.
+```
+
+---
+
+## Phase 1: Authentication MVP
+
+**Goal:** A working `proton-mcp login` subcommand that authenticates against the real Proton API, stores the session encrypted on disk, and refreshes the token on subsequent runs.
+
+### Background
+
+Read [docs/proton/authentication-flows.md](proton/authentication-flows.md) section "Recommendation for MCP Server Auth" before starting. The recommended design is "first run interactive, steady state headless". This phase implements the first run.
+
+The reference implementation for SRP login + token storage is `~/Projects/proton-bridge/internal/bridge/user.go`, function `LoginFull` (lines 194-247). Read it. You will implement essentially the same flow, minus the GUI callback indirection.
+
+### Tasks
+
+- [ ] Create `internal/auth/login.go` with the login flow:
+  ```go
+  package auth
+
+  import (
+      "context"
+      "errors"
+      "fmt"
+
+      "github.com/ProtonMail/go-proton-api"
+  )
+
+  type Credentials struct {
+      Username string
+      Password string
+  }
+
+  type Session struct {
+      AuthUID      string
+      RefreshToken string
+      KeyPass      []byte // Salted mailbox password for key decryption
+      UserID       string
+      PrimaryEmail string
+  }
+
+  func Login(ctx context.Context, manager *proton.Manager, creds Credentials, getTOTP func() (string, error)) (*Session, error) {
+      client, auth, err := manager.NewClientWithLogin(ctx, creds.Username, []byte(creds.Password))
+      if err != nil {
+          return nil, fmt.Errorf("login failed: %w", err)
+      }
+
+      // Reject two-password mode — not supported in this server
+      if auth.PasswordMode == proton.TwoPasswordMode {
+          _ = client.AuthDelete(ctx)
+          return nil, errors.New("two-password mode is not supported by proton-mcp; please use single-password mode")
+      }
+
+      // Handle 2FA if required
+      if auth.TwoFA.Enabled & proton.HasTOTP != 0 {
+          totp, err := getTOTP()
+          if err != nil {
+              _ = client.AuthDelete(ctx)
+              return nil, fmt.Errorf("TOTP required: %w", err)
+          }
+          if err := client.Auth2FA(ctx, proton.Auth2FAReq{TwoFactorCode: totp}); err != nil {
+              _ = client.AuthDelete(ctx)
+              return nil, fmt.Errorf("2FA failed: %w", err)
+          }
+      }
+
+      // FIDO2 not supported
+      if auth.TwoFA.Enabled & proton.HasFIDO2 != 0 && auth.TwoFA.Enabled & proton.HasTOTP == 0 {
+          _ = client.AuthDelete(ctx)
+          return nil, errors.New("FIDO2-only 2FA is not supported; please enable TOTP")
+      }
+
+      // Fetch user info and key salts
+      user, err := client.GetUser(ctx)
+      if err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("get user failed: %w", err)
+      }
+      salts, err := client.GetSalts(ctx)
+      if err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("get salts failed: %w", err)
+      }
+
+      // Salt the password to derive the key password
+      saltedKeyPass, err := salts.SaltForKey([]byte(creds.Password), user.Keys.Primary().ID)
+      if err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("salt for key failed: %w", err)
+      }
+
+      // Verify the key password actually unlocks the user's primary key
+      if _, err := user.Keys.Unlock(saltedKeyPass, nil); err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("key unlock failed: %w", err)
+      }
+
+      return &Session{
+          AuthUID:      auth.UID,
+          RefreshToken: auth.RefreshToken,
+          KeyPass:      saltedKeyPass,
+          UserID:       user.ID,
+          PrimaryEmail: user.Email,
+      }, nil
+  }
+  ```
+- [ ] Create `internal/auth/vault.go` with AES-256-GCM encryption:
+  ```go
+  package auth
+
+  import (
+      "crypto/aes"
+      "crypto/cipher"
+      "crypto/rand"
+      "encoding/json"
+      "errors"
+      "io"
+      "os"
+      "path/filepath"
+  )
+
+  const vaultFileName = "session.enc"
+
+  // Save encrypts the session and writes it to disk
+  func SaveSession(s *Session, vaultDir string, encryptionKey []byte) error {
+      data, err := json.Marshal(s)
+      if err != nil {
+          return err
+      }
+      block, err := aes.NewCipher(encryptionKey)
+      if err != nil {
+          return err
+      }
+      gcm, err := cipher.NewGCM(block)
+      if err != nil {
+          return err
+      }
+      nonce := make([]byte, gcm.NonceSize())
+      if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+          return err
+      }
+      ciphertext := gcm.Seal(nonce, nonce, data, nil)
+      if err := os.MkdirAll(vaultDir, 0700); err != nil {
+          return err
+      }
+      return os.WriteFile(filepath.Join(vaultDir, vaultFileName), ciphertext, 0600)
+  }
+
+  // Load reads and decrypts the session from disk
+  func LoadSession(vaultDir string, encryptionKey []byte) (*Session, error) {
+      ciphertext, err := os.ReadFile(filepath.Join(vaultDir, vaultFileName))
+      if err != nil {
+          return nil, err
+      }
+      block, err := aes.NewCipher(encryptionKey)
+      if err != nil {
+          return nil, err
+      }
+      gcm, err := cipher.NewGCM(block)
+      if err != nil {
+          return nil, err
+      }
+      if len(ciphertext) < gcm.NonceSize() {
+          return nil, errors.New("vault file too short")
+      }
+      nonce := ciphertext[:gcm.NonceSize()]
+      ct := ciphertext[gcm.NonceSize():]
+      plaintext, err := gcm.Open(nil, nonce, ct, nil)
+      if err != nil {
+          return nil, err
+      }
+      var s Session
+      if err := json.Unmarshal(plaintext, &s); err != nil {
+          return nil, err
+      }
+      return &s, nil
+  }
+  ```
+- [ ] Create `internal/auth/keyderive.go` to derive the vault encryption key. Use a combination of machine ID + a random salt stored alongside the vault. This protects against the vault file being copied to another machine. (Bridge does something similar with platform keychain integration; for simplicity, derive from `/etc/machine-id` on Linux, system UUID on macOS, machine GUID on Windows. Document this isn't bulletproof — it's a deterrent against accidental disclosure.)
+- [ ] Create `internal/auth/refresh.go`:
+  ```go
+  package auth
+
+  import (
+      "context"
+      "fmt"
+
+      "github.com/ProtonMail/go-proton-api"
+  )
+
+  // Refresh creates a fresh authenticated client from a stored session
+  func Refresh(ctx context.Context, manager *proton.Manager, s *Session) (*proton.Client, *Session, error) {
+      client, newAuth, err := manager.NewClientWithRefresh(ctx, s.AuthUID, s.RefreshToken)
+      if err != nil {
+          return nil, nil, fmt.Errorf("refresh failed: %w", err)
+      }
+      // Update session with new tokens (refresh tokens rotate)
+      s.AuthUID = newAuth.UID
+      s.RefreshToken = newAuth.RefreshToken
+      return client, s, nil
+  }
+  ```
+- [ ] Add the `login` Cobra subcommand to `cmd/proton-mcp/main.go`:
+  ```go
+  var loginCmd = &cobra.Command{
+      Use:   "login",
+      Short: "Authenticate with Proton and store an encrypted session",
+      RunE:  runLogin,
+  }
+
+  func runLogin(cmd *cobra.Command, args []string) error {
+      // Prompt for credentials via stdin
+      // Call auth.Login with a TOTP callback that prompts via stdin
+      // Save session via auth.SaveSession
+      // Print success message with primary email
+  }
+  ```
+- [ ] Use `golang.org/x/term` for password input that doesn't echo to the terminal
+- [ ] Document failure modes in the error messages: two-password mode, FIDO2-only, human verification required (CAPTCHA), TOTP required but no TTY
+
+### Verification
+
+- [ ] `go run ./cmd/proton-mcp login` prompts for username, password (hidden), TOTP if enabled
+- [ ] On success, prints "Logged in as user@protonmail.com" and creates `~/.proton-mcp/session.enc`
+- [ ] The session file is mode 0600 and unreadable as plain text
+- [ ] Running `login` again overwrites the previous session
+- [ ] If Proton requires CAPTCHA (HV), the command exits with a clear error message instructing the user to wait or change network
+- [ ] If the account uses two-password mode, the command exits with a clear error
+- [ ] Unit tests for `vault.go` (encrypt/decrypt round-trip, tamper detection)
+- [ ] Unit tests for the Cobra command structure (cobra makes this easy)
+
+### Commit
+
+```
+feat: add login subcommand with SRP auth and encrypted session vault
+
+Implements interactive login via go-proton-api SRP. Stores AuthUID,
+RefreshToken, and salted key password in AES-256-GCM encrypted vault
+at ~/.proton-mcp/session.enc. Supports TOTP 2FA via stdin prompt.
+
+Two-password mode and FIDO2-only 2FA are explicitly rejected.
+CAPTCHA / human verification is not handled — user must wait or
+change network.
+```
+
+---
+
+## Phase 2: MCP Server Skeleton + Distribution + First Release
+
+**Goal:** A working `proton-mcp serve` subcommand that loads the encrypted session, refreshes the token, and exposes the `verify_session` tool over MCP STDIO. Plus full distribution: goreleaser, MCPB packaging, GitHub Releases. First installable artifact.
+
+### Background
+
+Read the Go MCP SDK documentation at `github.com/modelcontextprotocol/go-sdk` (the README and examples). The key concepts are `mcp.NewServer`, tool registration with `mcp.Tool`, and STDIO transport via `mcp.NewStdioServerTransport`.
+
+This phase intentionally has only one tool (`verify_session`) so that all the infrastructure (server skeleton, audit logging, rate limiting, distribution, MCPB packaging, releases) is built and proven before any real tool work begins.
+
+### Tasks
+
+#### Server skeleton
+
+- [ ] Create `internal/proton/client.go` — a thin wrapper around `proton.Client` that adds:
+  - Rate limit handling (retry on 429 with `Retry-After`)
+  - Structured error mapping (convert go-proton-api errors to MCP-friendly errors)
+  - A reference to the `AuditLogger`
+- [ ] Create `internal/audit/logger.go` — JSONL audit log to a file:
+  ```go
+  type AuditEntry struct {
+      Timestamp time.Time `json:"ts"`
+      Operation string    `json:"op"`
+      Input     any       `json:"input,omitempty"`
+      Duration  string    `json:"duration"`
+      Error     string    `json:"error,omitempty"`
+  }
+
+  type AuditLogger interface {
+      Log(entry AuditEntry)
+      Close() error
+  }
+  ```
+- [ ] Implement `Audited` generic helper in `internal/audit/middleware.go` per the pattern shown above
+- [ ] Create `internal/proton/ratelimit.go` — wrap API calls in a retry loop:
+  ```go
+  func WithRateLimit[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+      const maxRetries = 5
+      var zero T
+      for attempt := 0; attempt <= maxRetries; attempt++ {
+          result, err := fn()
+          if err == nil {
+              return result, nil
+          }
+          var apiErr *proton.APIError
+          if errors.As(err, &apiErr) && apiErr.Status == 429 {
+              retryAfter := parseRetryAfter(apiErr) // from header or default
+              select {
+              case <-ctx.Done():
+                  return zero, ctx.Err()
+              case <-time.After(retryAfter):
+                  continue
+              }
+          }
+          return zero, err
+      }
+      return zero, errors.New("rate limit exceeded after retries")
+  }
+  ```
+- [ ] Create `internal/mcp/server.go` — initialize the MCP server, register tools:
+  ```go
+  package mcp
+
+  import (
+      "context"
+
+      "github.com/modelcontextprotocol/go-sdk/mcp"
+      "github.com/grover/proton-mcp/internal/proton"
+  )
+
+  func NewServer(client *proton.Client) *mcp.Server {
+      s := mcp.NewServer("proton-mcp", "0.1.0")
+      RegisterVerifySession(s, client)
+      return s
+  }
+  ```
+- [ ] Create `internal/mcp/tools/verify_session.go` — the first tool:
+  ```go
+  package tools
+
+  import (
+      "context"
+
+      "github.com/modelcontextprotocol/go-sdk/mcp"
+      "github.com/grover/proton-mcp/internal/proton"
+  )
+
+  type VerifySessionResult struct {
+      Email           string `json:"email"`
+      UserID          string `json:"userId"`
+      SessionValid    bool   `json:"sessionValid"`
+  }
+
+  func RegisterVerifySession(s *mcp.Server, client *proton.Client) {
+      s.AddTool(mcp.Tool{
+          Name:        "verify_session",
+          Description: "Verify the Proton API session is valid. Returns the authenticated user's email.",
+          // Annotations: ReadOnly hint, no destructive
+      }, func(ctx context.Context, _ struct{}) (VerifySessionResult, error) {
+          user, err := client.GetUser(ctx)
+          if err != nil {
+              return VerifySessionResult{SessionValid: false}, err
+          }
+          return VerifySessionResult{
+              Email:        user.Email,
+              UserID:       user.ID,
+              SessionValid: true,
+          }, nil
+      })
+  }
+  ```
+- [ ] Add the `serve` Cobra subcommand to `cmd/proton-mcp/main.go`:
+  ```go
+  var serveCmd = &cobra.Command{
+      Use:   "serve",
+      Short: "Start the MCP server (STDIO transport)",
+      RunE:  runServe,
+  }
+
+  func runServe(cmd *cobra.Command, args []string) error {
+      ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+      defer cancel()
+
+      // Load session from vault
+      session, err := auth.LoadSession(vaultDir, encryptionKey)
+      if err != nil {
+          return fmt.Errorf("load session: %w (run 'proton-mcp login' first)", err)
+      }
+
+      // Refresh token
+      manager := proton.New(...)
+      client, session, err := auth.Refresh(ctx, manager, session)
+      if err != nil {
+          return fmt.Errorf("refresh failed: %w", err)
+      }
+      // Save updated session (refresh tokens rotate)
+      _ = auth.SaveSession(session, vaultDir, encryptionKey)
+
+      // Wrap client with rate limit + audit
+      protonClient := proton.NewClient(client, auditLogger)
+
+      // Build MCP server
+      mcpServer := mcp.NewServer(protonClient)
+
+      // Run on STDIO transport
+      transport := mcp.NewStdioServerTransport()
+      return mcpServer.Serve(ctx, transport)
+  }
+  ```
+
+#### Distribution
+
+- [ ] Create `.goreleaser.yml`:
+  ```yaml
+  project_name: proton-mcp
+  builds:
+    - main: ./cmd/proton-mcp
+      binary: proton-mcp
+      env: [CGO_ENABLED=0]
+      goos: [linux, darwin, windows]
+      goarch: [amd64, arm64]
+      ignore:
+        - { goos: windows, goarch: arm64 }
+  archives:
+    - format: tar.gz
+      format_overrides:
+        - { goos: windows, format: zip }
+  release:
+    github:
+      owner: grover
+      name: proton-mcp
+  changelog:
+    sort: asc
+  ```
+- [ ] Create `.github/workflows/release.yml`:
+  ```yaml
+  name: Release
+  on:
+    push:
+      tags: ['v*']
+  jobs:
+    goreleaser:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with: { fetch-depth: 0 }
+        - uses: actions/setup-go@v5
+          with: { go-version: '1.22' }
+        - uses: goreleaser/goreleaser-action@v6
+          with:
+            args: release --clean
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build MCPB package
+          run: go run ./cmd/build-mcpb
+        - name: Upload MCPB to release
+          # ... attach proton-mcp.mcpb to the release
+  ```
+
+#### MCPB packaging
+
+- [ ] Create `manifest.json` in the repo root, adapted from the old repo. Reference the Go binary instead of a Node.js script. Read the old `manifest.json` first to understand the schema.
+- [ ] Create `cmd/build-mcpb/main.go` — a Go program that builds the `.mcpb` zip:
+  - Reads `manifest.json`
+  - Includes `proton-mcp` (the compiled binary for the current platform)
+  - Includes `assets/icon.svg` and other assets referenced in the manifest
+  - Zips everything to `proton-mcp.mcpb`
+- [ ] Document MCPB installation in `README.md`
+
+#### Documentation
+
+- [ ] Update `README.md` with:
+  - Project description
+  - Install instructions (download from releases, or `go install`)
+  - Quickstart (`login`, then `serve`)
+  - List of tools (just `verify_session` for now)
+  - Note that this is v0.1.0 — feature parity work in progress
+- [ ] Add `[v0.1.0]` section to `CHANGELOG.md`
+- [ ] Document the configuration model in `docs/configuration.md` (currently just the vault location)
+
+### Verification
+
+- [ ] `go run ./cmd/proton-mcp serve` (after `login`) starts the server, blocks on stdin
+- [ ] Connect via the MCP Inspector (`npx @modelcontextprotocol/inspector`) using STDIO transport pointed at the serve command
+- [ ] `verify_session` appears in the tool list
+- [ ] Calling `verify_session` returns the real user's email
+- [ ] Audit log file is created and contains a JSONL entry per tool call
+- [ ] `goreleaser release --snapshot --clean` produces binaries for all platforms in `dist/`
+- [ ] `go run ./cmd/build-mcpb` produces a valid `proton-mcp.mcpb` file
+- [ ] Installing the MCPB in Claude Desktop makes `verify_session` available
+- [ ] CI passes
+- [ ] Tag `v0.1.0` and verify the release workflow produces a GitHub Release with all binaries and the MCPB
+
+### Commit and release
+
+```
+feat: add MCP server skeleton with verify_session and full distribution
+
+- serve subcommand starts the MCP server on STDIO
+- verify_session tool returns authenticated user info
+- Rate limit handling via retry on 429 with Retry-After
+- JSONL audit logger
+- goreleaser config for cross-platform binaries
+- Adapted manifest.json + build-mcpb for Claude Desktop packaging
+- Tag v0.1.0
+```
+
+---
+
+## Phase 3: Smoke Testing Infrastructure
+
+**Goal:** A reliable smoke test harness that runs against both the real Proton API (interactive) and an in-process fake server (automated, headless, CI-suitable).
+
+### Background
+
+Read `~/Projects/proton-bridge/tests/api_test.go` to see how Bridge uses the `go-proton-api/server.Server` fake API server for its own integration tests. The fake server is part of the go-proton-api package and exposes the full API surface as an in-process HTTP server with a deterministic dataset.
+
+### Tasks
+
+- [ ] Create `cmd/smoketest/main.go` with two modes:
+  ```go
+  package main
+
+  import (
+      "flag"
+      "log"
+  )
+
+  func main() {
+      fakeMode := flag.Bool("fake", false, "Run against in-process fake server instead of real Proton API")
+      flag.Parse()
+
+      if *fakeMode {
+          runFakeMode()
+      } else {
+          runRealMode()
+      }
+  }
+  ```
+
+#### Mode A: Real account
+
+- [ ] `go run ./cmd/smoketest` (no `--fake`):
+  - Pre-flight: kill any process holding the Inspector port (use `lsof -ti tcp:6277 | xargs kill` style logic from the old repo's `run_smoketest.sh`)
+  - Load `.env` via `github.com/joho/godotenv`
+  - Verify the user has run `proton-mcp login` previously (check vault file exists). **Do not** prompt for TOTP from the smoke test command — that's a manual one-time setup step.
+  - Start `proton-mcp serve` as a subprocess
+  - Start the MCP Inspector pointed at the serve subprocess
+  - Print connection details to stdout
+  - Wait for SIGINT to clean up
+
+#### Mode B: Fake server (CI-suitable)
+
+- [ ] `go run ./cmd/smoketest --fake`:
+  - Spin up `go-proton-api/server.Server` in-process
+  - Pre-populate it with deterministic test data:
+    - A test user with a known password
+    - Several labels (system + custom)
+    - Several folders
+    - Messages in INBOX with a mix of: read/unread, with/without attachments, in various labels
+  - Authenticate against the fake server (using the test password)
+  - Start the MCP server pointing at the fake server URL
+  - Run scripted scenarios as direct MCP protocol calls (no Inspector UI)
+  - Assert expected outcomes
+  - Tear down everything cleanly
+  - Exit non-zero on any assertion failure
+
+- [ ] Create `internal/testfixtures/fakeserver.go` with helpers to set up the fake server with deterministic data
+- [ ] Create `internal/testfixtures/scenarios.go` with the scripted scenarios per phase
+
+### Scenarios per phase
+
+The fake-server scenarios grow as each phase adds tools:
+
+| Phase | Scenarios |
+|---|---|
+| 3 (this phase) | `verify_session` returns the test user's email — proves end-to-end harness works |
+| 4 | + `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`, verify attachment metadata in summaries |
+| 5 | + `mark_read` an email, verify it's read, `revert_operations`, verify it's unread again |
+| 6 | + `create_folder` with a path, verify it appears in `get_folders`, `delete_folder`, verify it's gone |
+| 7 | + `move_emails` from INBOX to a folder, verify; `add_labels` then `remove_labels`, verify |
+| 8 | + `fetch_message` returns a body; `fetch_attachment` returns base64 content |
+
+`verify_session` is included in **every** phase's scenarios as a sanity check.
+
+### Tasks for documentation
+
+- [ ] Create `docs/smoke-tests.md` listing all current scenarios
+- [ ] Update `README.md` with the smoke test instructions
+- [ ] Add a CI job that runs `go run ./cmd/smoketest --fake` on every push
+
+### Verification
+
+- [ ] `go run ./cmd/smoketest --fake` runs end-to-end against the fake server in <10 seconds, exits 0
+- [ ] CI runs the fake-mode smoke test and reports pass/fail
+- [ ] `go run ./cmd/smoketest` (real mode) starts the Inspector, connects to the real Proton account, and `verify_session` returns the user's email
+- [ ] The fake server scenarios are documented in `docs/smoke-tests.md`
+
+### Commit
+
+```
+test: add smoke test infrastructure with fake server automation
+
+Mode A: interactive harness against real Proton account via Inspector.
+Mode B: headless scripted scenarios against go-proton-api fake server.
+CI runs Mode B on every push.
+```
+
+---
+
+## Phase 4: Read Tools (with redesigned summaries from day one)
+
+**Goal:** Ship the four basic read tools (`get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`) with attachment metadata in summaries from the start. Release v0.2.0.
+
+### Background
+
+The TypeScript implementation has open issue #57 to move attachment metadata from `fetch_message` into `EmailSummary`. The Go port should ship the redesigned shape from the very first read tool — no later breaking change.
+
+Read `~/Projects/proton-bridge/internal/services/imapservice/connector.go` for how Bridge calls `client.GetMessageMetadataPage` and similar methods. The pagination patterns and label filtering are the relevant references.
+
+### Tasks
+
+#### Types
+
+- [ ] Create `internal/types/email.go` with the data types:
+  ```go
+  package types
+
+  type EmailID = string // ProtonMail message ID, opaque
+
+  type AttachmentMetadata struct {
+      Filename    string `json:"filename"`
+      Size        int    `json:"size"`
+      ContentType string `json:"contentType"`
+      PartID      string `json:"partId"`
+  }
+
+  type EmailSummary struct {
+      ID          EmailID              `json:"id"`
+      Subject     string               `json:"subject"`
+      From        string               `json:"from"`
+      To          []string             `json:"to"`
+      Date        time.Time            `json:"date"`
+      Unread      bool                 `json:"unread"`
+      LabelIDs    []string             `json:"labelIds"`
+      Attachments []AttachmentMetadata `json:"attachments,omitempty"`
+  }
+
+  type FolderInfo struct {
+      ID           string `json:"id"`
+      Path         string `json:"path"`
+      MessageCount int    `json:"messageCount"`
+      UnreadCount  int    `json:"unreadCount"`
+  }
+
+  type LabelInfo struct {
+      // No path, no ID — labels expose name only
+      Name         string `json:"name"`
+      MessageCount int    `json:"messageCount"`
+      UnreadCount  int    `json:"unreadCount"`
+  }
+  ```
+  Note: `LabelInfo` deliberately omits the label ID. The MCP server uses label names externally and resolves them to IDs internally. This matches the TypeScript design.
+
+#### Tool result types
+
+- [ ] Create `internal/mcp/results.go` with the generic result wrappers:
+  ```go
+  type ToolStatus string
+
+  const (
+      StatusSucceeded ToolStatus = "succeeded"
+      StatusPartial   ToolStatus = "partial"
+      StatusFailed    ToolStatus = "failed"
+  )
+
+  type SingleToolResult[T any] struct {
+      Status ToolStatus `json:"status"`
+      Data   T          `json:"data"`
+  }
+
+  type ListToolResult[T any] struct {
+      Status ToolStatus `json:"status"`
+      Items  []T        `json:"items"`
+  }
+
+  type BatchItemResult[T any] struct {
+      ID     string  `json:"id"`
+      Status string  `json:"status"`
+      Data   *T      `json:"data,omitempty"`
+      Error  *string `json:"error,omitempty"`
+  }
+
+  type BatchToolResult[T any] struct {
+      Status ToolStatus            `json:"status"`
+      Items  []BatchItemResult[T]  `json:"items"`
+  }
+  ```
+
+#### Tools
+
+- [ ] Implement `internal/mcp/tools/get_folders.go`:
+  - Calls `client.GetLabels()` (which returns ALL labels including system, folder, label)
+  - Filters to `LabelTypeFolder` + system folders (Inbox, Sent, Drafts, Trash, etc.)
+  - Maps each to `FolderInfo` with its path
+  - Returns `ListToolResult[FolderInfo]`
+- [ ] Implement `internal/mcp/tools/get_labels.go`:
+  - Calls `client.GetLabels()`
+  - Filters to `LabelTypeLabel` only
+  - Maps each to `LabelInfo` (name only — no ID, no path)
+  - Returns `ListToolResult[LabelInfo]`
+- [ ] Implement `internal/mcp/tools/list_mailbox.go`:
+  - Input: `{ mailbox: string, limit: int, offset: int }`
+  - Resolves the mailbox name to a label ID (system folders use known IDs; user folders/labels via `GetLabels()` lookup)
+  - Calls `client.GetMessageMetadataPage()` with pagination
+  - Maps each `proton.MessageMetadata` to `EmailSummary`, including attachment metadata from `AttachmentInfo`
+  - Returns `ListToolResult[EmailSummary]`
+- [ ] Implement `internal/mcp/tools/fetch_summaries.go`:
+  - Input: `{ ids: []string }`
+  - Calls `client.GetMessageMetadataPage()` filtered by IDs
+  - Same mapping as `list_mailbox`
+  - Returns `ListToolResult[EmailSummary]`
+- [ ] Register all four tools in `internal/mcp/server.go`
+- [ ] Add unit tests for the type mapping (proton.MessageMetadata -> EmailSummary)
+
+#### Tests
+
+- [ ] Add scenarios to `cmd/smoketest/main.go` Mode B:
+  - List folders, assert INBOX is present
+  - List labels, assert no IDs leak in the output
+  - List INBOX, assert at least one summary has attachment metadata
+  - Fetch summaries by ID, assert same shape as list_mailbox
+
+#### Documentation
+
+- [ ] Add tool entries to `docs/tools/README.md`
+- [ ] Update `[Unreleased]` in `CHANGELOG.md`
+- [ ] Update `README.md` to list the new tools
+
+### Verification
+
+- [ ] All four tools work via the MCP Inspector against a real account
+- [ ] Fake-server smoke test passes for Phase 4 scenarios
+- [ ] `LabelInfo` JSON output contains no `id` or `path` field — only `name`, `messageCount`, `unreadCount`
+- [ ] Summaries with attachments have populated `attachments` arrays
+- [ ] Tag `v0.2.0` and release
+
+### Commit and release
+
+```
+feat: add read tools (get_folders, get_labels, list_mailbox, fetch_summaries)
+
+EmailSummary includes attachment metadata from day one (issue #57 from
+the TypeScript repo). LabelInfo exposes name only — no IDs or paths.
+
+Tag v0.2.0
+```
+
+---
+
+## Phase 5: Operation Log + First Reversible Tools
+
+**Goal:** Build the operation log infrastructure and ship the simplest reversible tools (`mark_read`, `mark_unread`) plus `revert_operations`. Release v0.3.0.
+
+### Background
+
+Read [docs/impl/operation-log-revert.md](impl/operation-log-revert.md) for the design rationale. Translate the TypeScript snippets to Go. The Go version is structurally simpler because there's no IMAP UID instability — MessageIDs are stable, so the UID rewriting chain from the TypeScript implementation doesn't apply.
+
+### Tasks
+
+#### Operation log
+
+- [ ] Create `internal/ops/log.go`:
+  ```go
+  package ops
+
+  import (
+      "sync"
+      "time"
+  )
+
+  type ReversalSpec interface {
+      reversalSpec() // marker method
+  }
+
+  type NoopReversal struct{}
+  func (NoopReversal) reversalSpec() {}
+
+  type MarkReadReversal struct {
+      IDs []string
+  }
+  func (MarkReadReversal) reversalSpec() {}
+
+  type MarkUnreadReversal struct {
+      IDs []string
+  }
+  func (MarkUnreadReversal) reversalSpec() {}
+
+  // ... more reversal types added in later phases
+
+  type OperationRecord struct {
+      ID        int64
+      Tool      string
+      Reversal  ReversalSpec
+      Timestamp time.Time
+  }
+
+  const maxLogSize = 100
+
+  type Log struct {
+      mu      sync.Mutex
+      seq     int64
+      records []OperationRecord
+  }
+
+  func NewLog() *Log {
+      return &Log{records: make([]OperationRecord, 0, maxLogSize)}
+  }
+
+  func (l *Log) Push(tool string, reversal ReversalSpec) int64 {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      l.seq++
+      record := OperationRecord{
+          ID:        l.seq,
+          Tool:      tool,
+          Reversal:  reversal,
+          Timestamp: time.Now(),
+      }
+      l.records = append(l.records, record)
+      if len(l.records) > maxLogSize {
+          l.records = l.records[len(l.records)-maxLogSize:]
+      }
+      return record.ID
+  }
+
+  // GetFrom returns records from the given ID forward, in reverse-chronological order
+  func (l *Log) GetFrom(id int64) []OperationRecord {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      var found []OperationRecord
+      for _, r := range l.records {
+          if r.ID >= id {
+              found = append(found, r)
+          }
+      }
+      // Reverse for chronological-newest-first
+      for i, j := 0, len(found)-1; i < j; i, j = i+1, j-1 {
+          found[i], found[j] = found[j], found[i]
+      }
+      return found
+  }
+
+  func (l *Log) Has(id int64) bool {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      for _, r := range l.records {
+          if r.ID == id {
+              return true
+          }
+      }
+      return false
+  }
+
+  func (l *Log) Clear() {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      l.records = l.records[:0]
+  }
+  ```
+
+#### Tracked middleware
+
+- [ ] Create `internal/ops/middleware.go`:
+  ```go
+  // Tracked wraps a tool call and records its reversal in the operation log on success.
+  // The buildReversal callback receives the result and returns either a reversal spec
+  // or NoopReversal (for no-op cases like marking an already-read email as read).
+  func Tracked[T any](
+      log *Log,
+      tool string,
+      fn func() (T, error),
+      buildReversal func(T) ReversalSpec,
+  ) (T, int64, error) {
+      result, err := fn()
+      if err != nil {
+          var zero T
+          return zero, 0, err
+      }
+      reversal := buildReversal(result)
+      opID := log.Push(tool, reversal)
+      return result, opID, nil
+  }
+
+  // IrreversibleWhen clears the entire log if the predicate returns true after success.
+  // Used by destructive operations like delete_folder where reversal of prior operations
+  // becomes impossible.
+  func IrreversibleWhen[T any](
+      log *Log,
+      fn func() (T, error),
+      shouldClear func(T) bool,
+  ) (T, error) {
+      result, err := fn()
+      if err == nil && shouldClear(result) {
+          log.Clear()
+      }
+      return result, err
+  }
+  ```
+
+#### Tools
+
+- [ ] Implement `internal/mcp/tools/mark_read.go`:
+  - Input: `{ ids: []string }`
+  - Idempotency: fetch metadata first, only mark unread emails as read
+  - Call `client.MarkMessagesRead(ctx, ids...)`
+  - Build reversal: `MarkReadReversal{IDs: actuallyChangedIDs}` (or NoopReversal if nothing changed)
+  - Return `BatchToolResult[MarkReadResult]` with `operationId`
+- [ ] Implement `internal/mcp/tools/mark_unread.go` — same pattern, inverted
+- [ ] Implement `internal/mcp/tools/revert_operations.go`:
+  - Input: `{ operationId: int64 }`
+  - Validates the operation ID exists in the log (else `UNKNOWN_OPERATION_ID`)
+  - Walks log from the given ID forward in reverse-chronological order
+  - For each record, executes the reversal:
+    - `MarkReadReversal` -> `client.MarkMessagesUnread(ids)`
+    - `MarkUnreadReversal` -> `client.MarkMessagesRead(ids)`
+    - `NoopReversal` -> do nothing
+  - Returns `RevertResult` with per-step status
+- [ ] Wire `mark_read` and `mark_unread` to use `Tracked` middleware
+
+#### Tests
+
+- [ ] Add scenarios to fake-server smoke test:
+  - Mark an unread email as read, verify it's read
+  - Capture the operationId from the response
+  - Call `revert_operations` with that ID
+  - Verify the email is unread again
+  - Mark an already-read email as read, verify NoopReversal was recorded
+
+#### Documentation
+
+- [ ] Document the operation log pattern in `docs/impl/operation-log-revert.md` (port from TS version with Go snippets)
+- [ ] Add tool entries to `docs/tools/README.md`
+- [ ] Update `[Unreleased]` in `CHANGELOG.md`
+
+### Verification
+
+- [ ] Mark/unmark round-trip via the Inspector
+- [ ] Revert restores state
+- [ ] Idempotency: marking an already-read email as read records a NoopReversal
+- [ ] Fake-server smoke test passes
+- [ ] Tag `v0.3.0` and release
+
+### Commit and release
+
+```
+feat: add operation log + mark_read/mark_unread + revert_operations
+
+Implements the operation log ring buffer (100 entries, monotonic IDs)
+and the Tracked/IrreversibleWhen middleware helpers. mark_read and
+mark_unread are the first reversible tools, with idempotency-aware
+no-op detection.
+
+Tag v0.3.0
+```
+
+---
+
+## Phase 6: Folder/Label Management
+
+**Goal:** Ship `create_folder`, `create_label`, `delete_folder`, `delete_label`. Release v0.4.0.
+
+### Tasks
+
+- [ ] Add reversal types to `internal/ops/log.go`:
+  ```go
+  type CreateFolderReversal struct {
+      Path string
+  }
+  func (CreateFolderReversal) reversalSpec() {}
+
+  type CreateLabelReversal struct {
+      Name string
+  }
+  func (CreateLabelReversal) reversalSpec() {}
+  ```
+- [ ] Implement `internal/mcp/tools/create_folder.go`:
+  - Input: `{ path: string }`
+  - Validate path starts with `Folders/` and is non-trivial
+  - Call `client.CreateLabel(LabelTypeFolder, ...)` with parent ID resolution for nested paths (see Bridge's `createFolder` in `connector.go` for reference)
+  - On success: `CreateFolderReversal{Path: path}` for the operation log
+  - Return `SingleToolResult[CreateFolderResult]` with `{ path, created }`
+  - Idempotency: if the folder already exists, return `{ created: false }` and `NoopReversal`
+- [ ] Implement `internal/mcp/tools/create_label.go`:
+  - Input: `{ name: string }`
+  - Validate name does not contain `/`
+  - Call `client.CreateLabel(LabelTypeLabel, name)` (no parent — labels are flat)
+  - On success: `CreateLabelReversal{Name: name}`
+  - Return `{ name, created }` (NOT `path` — see [docs/impl/label-handling.md](impl/label-handling.md))
+  - Idempotency: if the label already exists, return `{ created: false }` and `NoopReversal`
+- [ ] Implement `internal/mcp/tools/delete_folder.go`:
+  - Input: `{ path: string }`
+  - Validate path starts with `Folders/`
+  - Reject if it's a special-use folder
+  - Call `client.DeleteLabel(folderID)`
+  - Use `IrreversibleWhen` middleware: when `deleted == true`, clear the entire operation log
+  - Return `{ path, deleted }`
+  - Idempotency: if the folder doesn't exist, return `{ deleted: false }` (do not clear log)
+- [ ] Implement `internal/mcp/tools/delete_label.go`:
+  - Input: `{ name: string }`
+  - Resolve name -> label ID
+  - Call `client.DeleteLabel(labelID)`
+  - Use `IrreversibleWhen` middleware
+  - Return `{ name, deleted }`
+- [ ] Add reversal execution for `CreateFolderReversal` and `CreateLabelReversal` in `revert_operations`:
+  - `CreateFolderReversal{Path}` -> `delete_folder(path)`
+  - `CreateLabelReversal{Name}` -> `delete_label(name)`
+- [ ] Add scenarios to fake-server smoke test:
+  - Create a folder, assert it appears in `get_folders`
+  - Delete it, assert it's gone
+  - Create a label, assert it appears in `get_labels`
+  - Delete it
+  - Create-then-revert: verify the folder/label is deleted by the revert
+
+### Documentation
+
+- [ ] Tool entries in `docs/tools/README.md`
+- [ ] CHANGELOG entry
+
+### Verification
+
+- [ ] All four tools work via Inspector
+- [ ] Fake-server smoke test passes
+- [ ] Idempotency verified
+- [ ] `delete_folder` clearing the log is verified by attempting a revert after a delete (should fail with UNKNOWN_OPERATION_ID)
+- [ ] Tag `v0.4.0` and release
+
+### Commit
+
+```
+feat: add folder/label CRUD tools
+
+create_folder, create_label, delete_folder, delete_label.
+Idempotent — repeated calls are no-ops. delete_folder and delete_label
+are IrreversibleWhen, clearing the operation log on actual deletion.
+
+Tag v0.4.0
+```
+
+---
+
+## Phase 7: Email Movement and Labels
+
+**Goal:** Ship `move_emails`, `add_labels`, `remove_labels`. Release v0.5.0.
+
+### Background
+
+Read `~/Projects/proton-bridge/internal/services/imapservice/connector.go` `MoveMessages` (around line 506) for the asymmetric label/folder MOVE logic. The bridge handles:
+- Moving between labels: label destination, unlabel source
+- Moving label -> folder: label destination, unlabel source
+- Moving folder -> label: label destination, source stays (this is unusual!)
+- Moving folder -> folder: relies on `shouldExpungeOldLocation` flag
+
+Your Go MCP version doesn't need to mirror exactly because it's not constrained by IMAP semantics. But the underlying API calls (`client.LabelMessages`, `client.UnlabelMessages`) are the same.
+
+### Tasks
+
+- [ ] Add reversal types:
+  ```go
+  type MoveBatchReversal struct {
+      Moves []struct {
+          IDs       []string
+          FromLabel string
+          ToLabel   string
+      }
+  }
+
+  type AddLabelsReversal struct {
+      IDs       []string
+      LabelName string
+  }
+
+  type RemoveLabelsReversal struct {
+      IDs       []string
+      LabelName string
+  }
+  ```
+- [ ] Implement `internal/mcp/tools/move_emails.go`:
+  - Input: `{ ids: []string, targetMailbox: string }`
+  - Resolve target mailbox name to label ID
+  - Group input emails by their current label (need to fetch current state)
+  - For each source label, call `client.LabelMessages(ids, targetID)` then `client.UnlabelMessages(ids, sourceID)`
+  - Build reversal: swap source/target for each group
+  - Return `BatchToolResult[MoveResult]` with `operationId`
+- [ ] Implement `internal/mcp/tools/add_labels.go`:
+  - Input: `{ ids: []string, labelNames: []string }`
+  - Resolve each label name to ID
+  - Call `client.LabelMessages(ids, labelID)` for each label
+  - **Response shape: `{ labelName, applied: bool }`** — no path, no IDs
+  - Return `BatchToolResult` with per-email per-label results
+  - Reversal: `RemoveLabelsReversal{IDs, LabelName}` for each successfully applied label
+- [ ] Implement `internal/mcp/tools/remove_labels.go`:
+  - Input: `{ ids: []string, labelNames: []string }`
+  - Resolve each label name to ID
+  - Call `client.UnlabelMessages(ids, labelID)` for each label
+  - Response: `{ labelName, removed: bool }`
+  - Reversal: `AddLabelsReversal{IDs, LabelName}`
+- [ ] Implement reversal execution for the new reversal types
+- [ ] Add fake-server smoke test scenarios:
+  - Move email INBOX -> Folders/Test, verify
+  - Move back via revert, verify
+  - Add label, verify it's applied (no path leaks in response!)
+  - Remove label, verify
+  - Round-trip add/remove via revert
+
+### Documentation
+
+- [ ] Tool entries in `docs/tools/README.md` — emphasize no-leak rule for `add_labels` response
+- [ ] CHANGELOG entry — explicitly mention this fixes the TS issue #54 (`add_labels` path leakage) by design
+
+### Verification
+
+- [ ] All three tools work via Inspector
+- [ ] `add_labels` response contains `labelName` and `applied`, never `labelPath` or `newId`
+- [ ] Fake-server smoke test passes
+- [ ] Tag `v0.5.0` and release
+
+### Commit
+
+```
+feat: add move_emails, add_labels, remove_labels
+
+add_labels response uses { labelName, applied } — no IMAP path or
+copy UID leakage (fixes TS issue #54 by design). All three tools are
+fully reversible via revert_operations.
+
+Tag v0.5.0
+```
+
+---
+
+## Phase 8: Message Body, Search, and Attachment Tools
+
+**Goal:** Ship `fetch_message` (body-only, redesigned per TS issue #58), `fetch_attachment`, `search_mailbox`. Release v0.6.0.
+
+### Background
+
+This is the first phase that touches PGP decryption. Read `~/Projects/proton-bridge/internal/services/imapservice/connector.go` function `GetMessageLiteral` (around line 216) for how Bridge fetches and decrypts a message. The pattern uses `gopenpgp` (which is already a dependency of `go-proton-api`).
+
+The redesigned `fetch_message` returns only the body (text/html), not the envelope fields. The envelope is already in the summary that the agent has from `list_mailbox` or `fetch_summaries`. Avoid re-duplication.
+
+### Tasks
+
+- [ ] Add types:
+  ```go
+  type EmailBody struct {
+      ID          EmailID `json:"id"`
+      ContentType string  `json:"contentType"` // "text/plain" or "text/html"
+      Body        string  `json:"body"`
+  }
+
+  type AttachmentContent struct {
+      EmailID     EmailID `json:"emailId"`
+      PartID      string  `json:"partId"`
+      Filename    string  `json:"filename"`
+      ContentType string  `json:"contentType"`
+      Data        string  `json:"data"` // base64
+      Size        int     `json:"size"`
+  }
+  ```
+- [ ] Implement `internal/mcp/tools/fetch_message.go`:
+  - Input: `{ id: string }`
+  - Call `client.GetFullMessage(ctx, id)` — returns the encrypted message
+  - Use the user's keyring (from session.KeyPass) to decrypt the body via gopenpgp
+  - Return `SingleToolResult[EmailBody]` — body content only
+- [ ] Implement `internal/mcp/tools/fetch_attachment.go`:
+  - Input: `{ emailId: string, partId: string }`
+  - Call `client.GetAttachment(ctx, partId)` — returns encrypted attachment
+  - Decrypt via gopenpgp using the appropriate key
+  - Return `SingleToolResult[AttachmentContent]` with base64-encoded data
+- [ ] Implement `internal/mcp/tools/search_mailbox.go`:
+  - Input: `{ mailbox: string, query: string, limit: int, offset: int }`
+  - Call `client.GetMessageMetadataPage()` with `Keyword` parameter
+  - Return `ListToolResult[EmailSummary]` (same shape as `list_mailbox`, includes attachment metadata)
+- [ ] Set up keyring management in `internal/proton/keys.go`:
+  - On `serve` startup, after refreshing the token, load and decrypt the user's primary key using `session.KeyPass`
+  - Store the keyring on the `ProtonClient` wrapper for use by decrypt operations
+  - Refresh keyring on token refresh
+
+### Tests
+
+- [ ] Add fake-server scenarios:
+  - Fetch a message body, assert it's decrypted plaintext/HTML (the fake server should provide test messages)
+  - Fetch an attachment, assert base64 length matches expected size
+  - Search for a keyword that exists in test data, assert at least one result with attachment metadata
+
+### Documentation
+
+- [ ] Tool entries in `docs/tools/README.md`
+- [ ] CHANGELOG entry — note `fetch_message` returns body only (TS issue #58 fixed by design)
+
+### Verification
+
+- [ ] Fetch a real message body via Inspector against a real account
+- [ ] Download a real attachment, verify it opens correctly
+- [ ] Search returns expected results
+- [ ] Fake-server smoke test passes
+- [ ] Tag `v0.6.0` and release
+
+### Commit
+
+```
+feat: add fetch_message, fetch_attachment, search_mailbox
+
+PGP decryption via gopenpgp using the stored salted key password.
+fetch_message returns body only — no envelope re-duplication
+(fixes TS issue #58 by design).
+
+Tag v0.6.0
+```
+
+---
+
+## Phase 9: Cutover
+
+**Goal:** Migrate users from `proton-bridge-mcp` to `proton-mcp`. No release.
+
+### Tasks
+
+- [ ] Open a PR against `~/Projects/proton-bridge-mcp` updating the README:
+  - Add a deprecation banner at the top: "This project is in maintenance mode. The actively developed Go version is at https://github.com/grover/proton-mcp"
+  - Add a "Migration Guide" section linking to a new doc
+- [ ] Create `docs/migration-from-typescript.md` in the new repo:
+  - For users coming from `proton-bridge-mcp`
+  - How to install the new MCPB
+  - How to migrate Claude Desktop configuration (the tool names are the same, so most existing usage should just work)
+  - Notes on the two tool changes: `verify_connectivity` -> `verify_session`, `drain_connections` removed
+  - Notes on the response shape changes: `fetch_message` body-only, `add_labels` no path
+- [ ] Update the new repo's README to link the migration guide
+- [ ] Add a section to the old repo's CHANGELOG noting the deprecation
+- [ ] Old repo enters maintenance mode: only security fixes
+- [ ] Set milestone in the old repo to track final maintenance work
+
+This phase produces no release. Cutover is a meta step.
+
+### Verification
+
+- [ ] Old repo README clearly directs users to the new one
+- [ ] Migration guide exists and is accurate
+- [ ] No silent breakage: users following the guide can install the new MCPB and continue with their existing Claude Desktop setup
+
+---
+
+## Phase 10: Cross-cutting Improvements
+
+**Goal:** Operational quality improvements after users have migrated. Release v0.7.0.
+
+### Tasks
+
+- [ ] **Audit log rotation** — port the design from TS issue #40. Use `gopkg.in/natefinch/lumberjack.v2` or implement simple size-based rotation in `internal/audit/`
+- [ ] **Better error mapping** — define structured error codes for the MCP responses:
+  - `AUTH_EXPIRED` — session needs re-login
+  - `RATE_LIMITED` — Proton API returned 429
+  - `LABEL_NOT_FOUND` — label name doesn't exist
+  - `EMAIL_NOT_FOUND` — message ID doesn't exist
+  - `INVALID_INPUT` — schema validation failure
+  - `INTERNAL` — anything else
+  - Return these codes in the MCP error responses so agents can react
+- [ ] **Rate limit refinements** — basic retry shipped in Phase 2, this phase adds:
+  - Configurable retry budget per call
+  - Metrics for rate-limit hits (logged via slog)
+  - Backoff jitter
+- [ ] **Telemetry / structured event logging** — use `log/slog` consistently across the codebase, ensure every tool call logs a structured event for production debugging
+- [ ] **Troubleshooting documentation** — create `docs/troubleshooting.md`:
+  - "Authentication errors" — what to do when refresh fails
+  - "Rate limit errors" — what they mean, how to back off
+  - "CAPTCHA / human verification" — how to recover (wait, change network, re-login)
+  - "Session expired mid-conversation" — instructing users to re-run `login`
+
+### Verification
+
+- [ ] Audit log rotates at the configured size
+- [ ] All error responses include structured error codes
+- [ ] Troubleshooting doc covers common failure modes
+- [ ] Tag `v0.7.0` and release
+
+### Commit
+
+```
+feat: cross-cutting improvements (audit log rotation, error codes, telemetry)
+
+Audit log size-based rotation. Structured MCP error codes for
+AUTH_EXPIRED, RATE_LIMITED, LABEL_NOT_FOUND, etc. Slog-based
+structured event logging for production debugging. Troubleshooting
+guide.
+
+Tag v0.7.0
+```
+
+---
+
+## Phase 11: HTTP/HTTPS Transports (Last)
+
+**Goal:** Add HTTP and HTTPS transports for non-STDIO use cases. Release v1.0.0 — feature parity with the TypeScript version.
+
+### Background
+
+Read `~/Projects/proton-bridge-mcp/src/http.ts` for the per-session model the TypeScript version uses. The Go MCP SDK should provide HTTP transport primitives — check its docs.
+
+### Tasks
+
+- [ ] Add `--http` flag to `serve`:
+  - Starts an HTTP server on a configurable port
+  - Bearer token auth via the `Authorization` header
+  - Per-session MCP server instances (one `mcp.Server` per HTTP session, keyed by session ID)
+- [ ] Add `--https` flag:
+  - Same as `--http` but with TLS
+  - Auto-generates a self-signed certificate if `--cert` and `--key` are not provided
+  - Use `crypto/tls` and `crypto/x509` from stdlib
+- [ ] Configuration via flags or env vars:
+  - `--port` / `PROTONMAIL_MCP_PORT`
+  - `--mcp-auth-token` / `PROTONMAIL_MCP_AUTH_TOKEN`
+  - `--cert`, `--key` (HTTPS)
+- [ ] Update the manifest.json to support HTTP mode if needed
+- [ ] Add fake-server smoke test scenarios for HTTP mode (Mode A only — Mode B can stay STDIO)
+- [ ] Document the configuration in `docs/configuration.md`
+
+### Verification
+
+- [ ] `proton-mcp serve --http --port 6283 --mcp-auth-token secret` starts HTTP server
+- [ ] MCP Inspector connects via HTTP with the Bearer header
+- [ ] Requests without the token return 401
+- [ ] HTTPS variant works with auto-generated cert
+- [ ] Multiple concurrent sessions work without cross-contamination
+- [ ] Tag `v1.0.0` and release
+
+### Commit and release
+
+```
+feat: add HTTP/HTTPS transports — v1.0.0 feature parity
+
+proton-mcp serve --http and --https with bearer token auth and
+per-session MCP server instances. Auto-generates self-signed cert
+for HTTPS if not provided.
+
+This release marks feature parity with proton-bridge-mcp.
+
+Tag v1.0.0
+```
+
+---
+
+## Documentation Maintenance
+
+Documentation is **not** a separate phase. Each phase that adds or changes a tool must, in the same commit series:
+
+- Add or update entries in `docs/tools/README.md`
+- Add an entry to `CHANGELOG.md` under `[Unreleased]`, then promote to a versioned section on release
+- Update `README.md` quickstart if relevant
+- Update `ARCHITECTURE.md` if the structure changes
+
+Don't defer documentation. It's part of the work.
+
+## Release Cadence Summary
+
+| Phase | Release | Tools / focus |
+|---|---|---|
+| 2 | v0.1.0 | `verify_session` + skeleton + MCPB + goreleaser + rate limit handling |
+| 4 | v0.2.0 | + `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries` (with attachment metadata) |
+| 5 | v0.3.0 | + `mark_read`, `mark_unread`, `revert_operations` (operation log online) |
+| 6 | v0.4.0 | + `create_folder`, `create_label`, `delete_folder`, `delete_label` |
+| 7 | v0.5.0 | + `move_emails`, `add_labels`, `remove_labels` |
+| 8 | v0.6.0 | + `fetch_message` (body only), `fetch_attachment`, `search_mailbox` |
+| 10 | v0.7.0 | Audit log rotation, error mapping, telemetry |
+| 11 | v1.0.0 | + HTTP/HTTPS transports — feature parity |
+
+Phase 3 (smoke test infrastructure) and Phase 9 (cutover) produce no release.
+
+## A short Go primer
+
+This appendix is for the user reading along, not for Claude. Claude should already know Go. If you're the user and you're new to Go, here are the absolute minimum concepts to recognize what's in this roadmap:
+
+**Packages**: A directory of `.go` files. Imported by path: `import "github.com/grover/proton-mcp/internal/auth"`. Function visibility is by capitalization: `Login` is exported (public), `login` is package-private.
+
+**Methods on structs**: Go has no classes. A "method" is a function whose first parameter is the receiver, written as `func (s *Session) Refresh() error`. The `*` means pointer (mutable reference), like `Session&` in C++.
+
+**Interfaces**: A list of method signatures. Any type that implements those methods automatically satisfies the interface — no `implements` keyword needed. Go's "duck typing" with compile-time checks.
+
+**Errors**: Returned as the last value alongside a result. Always check `if err != nil { return err }`. Wrapping: `fmt.Errorf("context: %w", err)`.
+
+**Context**: `context.Context` is passed as the first parameter to every function that does I/O. It carries cancellation signals and deadlines. Always pass it through.
+
+**Goroutines and channels**: Go's concurrency primitives. You probably won't need them much in this roadmap — most of the work is sequential request/response.
+
+**Generics**: Added in Go 1.18. Used for the tool result types: `SingleToolResult[T any]`. The syntax is similar to TypeScript generics.
+
+**`go run` vs `go build`**: `go run ./cmd/X` compiles and runs in one step (slower, good for dev). `go build ./...` produces a binary you can ship.
+
+**The standard library is huge**: `net/http`, `encoding/json`, `crypto/aes`, `os`, `time`, `log/slog`, `context`, `sync` — almost everything you need is in the stdlib. Be skeptical of adding dependencies.
+
+**Read Bridge**: When you're stuck on a Go pattern, look at how `~/Projects/proton-bridge` does it. It's a 70k-line production Go codebase using the same library. You will rarely have to invent a pattern from scratch.

--- a/docs/go-migration-roadmap.md
+++ b/docs/go-migration-roadmap.md
@@ -1,3 +1,1705 @@
+# Go Migration Roadmap for `proton-mail-mcp`
+
+> This document is a roadmap for migrating the proton-bridge-mcp TypeScript project to a new Go project called `proton-mail-mcp`. It is **written for Claude as the executor** in the new repo. Read it cold, follow the phases in order, verify each phase before moving to the next.
+
+## Reference repos
+
+You will reference two existing repositories throughout this work:
+
+- **`~/Projects/proton-bridge-mcp`** — the TypeScript implementation being replaced. Use it as a reference for tool semantics, design decisions, test scenarios, and documentation patterns. Do not copy code; copy concepts.
+- **`~/Projects/proton-bridge`** — Proton's official Bridge, written in Go. It is the canonical example of how to use `go-proton-api` correctly. When in doubt about Go patterns or API usage, look here first.
+
+## Background reading (do this before Phase 0)
+
+Read these files in `~/Projects/proton-bridge-mcp` before starting. They contain context that this roadmap assumes you understand:
+
+1. [docs/proton/authentication-flows.md](proton/authentication-flows.md) — how Proton authenticates, what go-proton-api handles for you, and the TOTP/CAPTCHA discussion. The "Porting Evaluation" section explains why this migration is happening.
+2. [docs/proton/bridge-label-implementation.md](proton/bridge-label-implementation.md) — how Proton Bridge virtualizes labels as IMAP folders. This is the complexity the new server escapes by going direct to the API.
+3. [docs/impl/label-handling.md](impl/label-handling.md) — the rule that no virtualized path may leak into tool responses. Still applies in Go, but easier to honor because labels are native.
+4. [docs/impl/operation-log-revert.md](impl/operation-log-revert.md) — the operation log + revert design. You will reimplement this in Go in Phase 5.
+5. [docs/impl/mcp-tool-interfaces.md](impl/mcp-tool-interfaces.md) — tool result types (`SingleToolResult`, `BatchToolResult`, `ListToolResult`). Translate these to Go structs.
+
+## What this migration achieves
+
+The current TypeScript MCP server talks to ProtonMail through the Bridge IMAP daemon. This forces the server to deal with IMAP's virtualization of labels-as-folders, COPYUID resolution for label copies, Message-ID searches to find virtualized copies, UID rewriting during revert, and a connection pool. About a thousand lines of code exist solely to manage IMAP and undo its virtualization.
+
+The Go version eliminates IMAP entirely. It uses `go-proton-api` directly — the same library that Bridge uses internally. Labels become native label IDs. UIDs become stable MessageIDs. The connection pool disappears. The label devirtualization layer disappears. Authentication is handled by go-proton-api in a single function call.
+
+The end state is a single static Go binary that depends on no external runtime, talks directly to Proton's API, and exposes the same MCP tool surface as the TypeScript version (with two intentional changes documented below).
+
+## Recommendation: new repo, not fork
+
+Create a new GitHub repo named `proton-mail-mcp`. Do not fork `proton-bridge-mcp`. Reasons:
+
+- Different language entirely — no source is reused, only concepts and documentation
+- The new server doesn't depend on Bridge, so dropping "bridge" from the name reflects reality
+- A fork carries npm/Node.js git history that's irrelevant to a Go project
+- The new module path is `github.com/grover/proton-mail-mcp` — clean, no suffix
+- Forking implies incremental migration; this is a clean rewrite
+
+You will selectively copy documentation, design decisions, and assets from `~/Projects/proton-bridge-mcp` into the new repo. The old repo stays alive as the TypeScript implementation until Phase 9 cutover.
+
+## What to retain from the old repo
+
+### Documentation
+
+Copy these files into the new repo with minor edits where noted:
+
+| Source | Destination | Adaptation |
+|---|---|---|
+| `docs/proton/bridge-label-implementation.md` | Same path | None — historical reference |
+| `docs/proton/webclient-api-extraction.md` | Same path | Add a note: "Go path was chosen — see `authentication-flows.md`" |
+| `docs/proton/authentication-flows.md` | Same path | None — directly applicable |
+| `docs/impl/label-handling.md` | Same path | Update opening paragraph: labels are now native, not virtualized; the no-leak rule still applies but for different reasons (consistency with input format, not protecting against IMAP UID confusion) |
+| `docs/impl/operation-log-revert.md` | Same path | Translate code snippets from TypeScript to Go in Phase 5 |
+| `docs/impl/mcp-tool-interfaces.md` | Same path | Translate type examples to Go structs |
+| `docs/tools/README.md` | Same path | Will be updated per phase as tools land |
+| `docs/visuals.md` | Same path | Branding info you want, and visual style guide |
+
+### Documentation to drop entirely
+
+- `docs/IMAP.md` — no IMAP in the new server
+- `docs/bridge-repair/` — Bridge-specific reference content
+- `docs/plans/edd-*.md` and `docs/plans/prd-*.md` — TypeScript-specific implementation plans
+- `docs/ROADMAP.md` — replaced by this roadmap
+
+### Conventions to port (new CLAUDE.md)
+
+The old `CLAUDE.md` defines project conventions and the orchestrator workflow. Most of it is language-agnostic and worth keeping. The Go-adapted version should retain:
+
+- Operation modes (STDIO is primary; HTTP/HTTPS comes in Phase 11)
+- Tool categories (`read`, `mutating`, `destructive`, `maintenance`) and annotation presets (`READ_ONLY`, `MUTATING`, `DESTRUCTIVE`)
+- Operation log + revert design summary
+- Interface segregation principle: tool handlers depend on interfaces, not concrete types
+- Branch policy: `{type}/{issue#}-{title}` where type ∈ `bug`, `feat`, `refactor`, `docs`
+- Concurrent agent safety guidance
+- The orchestrator/QE/SWE/Reviewer persona rotation
+- EDD/PRD format for non-trivial changes
+- Engineering principles (TDD, clean code, fail fast, no fallbacks)
+
+The Go-adapted version should drop or replace:
+
+- Pre-commit checklist: replace `npm install -> lint -> build -> npm ci` with `go mod tidy -> go vet ./... -> golangci-lint run -> go test ./... -> go build ./...`
+- TypeScript-specific notes (Zod, NodeNext ESM imports, ts-jest)
+- npm-related sections (releases via release-it, MCPB packaging via build-mcpb.sh)
+- Smoke test commands (replace with `go run ./cmd/smoketest`)
+
+### Design concepts to re-implement in Go
+
+These are patterns from the TypeScript code that should be reproduced in idiomatic Go. They are not files to copy — they are designs to translate:
+
+1. **Tool result types** — `SingleToolResult[T]`, `BatchToolResult[T]`, `ListToolResult[T]` with a `status` field. Use Go generics (Go 1.18+).
+2. **Tool categories and annotations** — same taxonomy
+3. **Operation log** — ring buffer, monotonic IDs, FIFO eviction at 100 entries, no persistence
+4. **Interface segregation** — `ReadOnlyMailOps` and `MutatingMailOps` become Go interfaces; tool handlers accept these as parameters
+5. **`LabelInfo` with name only** — never expose IMAP paths or label IDs; same rule as TypeScript version
+6. **`CreateLabelResult { Name, Created }`** — same shape, no path leakage
+7. **No-op detection** — mutating operations compare before/after state, do not generate reversal entries for no-ops
+8. **`--login` CLI subcommand** for first-run auth (TOTP only, no CAPTCHA, no two-password mode)
+9. **MCP elicitation** for in-protocol prompts when the client supports it
+10. **Encrypted session vault** — analogous to Bridge's `vault.enc`, stores `{ AuthUID, RefreshToken, KeyPass }`
+
+### Cross-cutting concerns: the Go "middleware" pattern
+
+The TypeScript code uses `@Audited`, `@Tracked`, and `@IrreversibleWhen` decorators. Go has no decorators. The equivalent pattern is **wrapper functions that take a closure and return a wrapped version with cross-cutting behavior added**.
+
+Pattern:
+
+```go
+// AuditLogger writes JSONL audit events
+type AuditLogger interface {
+    Log(entry AuditEntry)
+}
+
+// Audited wraps a function call with audit logging.
+// Generic over the return type T.
+func Audited[T any](logger AuditLogger, op string, input any, fn func() (T, error)) (T, error) {
+    start := time.Now()
+    result, err := fn()
+    logger.Log(AuditEntry{
+        Operation: op,
+        Input:     input,
+        Duration:  time.Since(start),
+        Error:     errString(err),
+    })
+    return result, err
+}
+
+// Usage in a method:
+func (c *ProtonClient) MoveEmails(ctx context.Context, ids []EmailID, target string) (BatchResult[MoveResult], error) {
+    return Audited(c.audit, "move_emails", map[string]any{"ids": ids, "target": target},
+        func() (BatchResult[MoveResult], error) {
+            // actual implementation
+            return c.doMoveEmails(ctx, ids, target)
+        })
+}
+```
+
+This is the Go-idiomatic equivalent of decorators. It's slightly more verbose than TypeScript decorators but explicit — there is no hidden behavior. The same pattern works for `Tracked` (records reversal in operation log) and `IrreversibleWhen` (conditionally clears the log).
+
+You will implement these helper functions in Phase 5 when the operation log lands.
+
+### Tool catalog
+
+Reuse the exact tool names and semantics from the TypeScript implementation, with two intentional changes:
+
+| Category | Tools |
+|---|---|
+| **read** | `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`, `fetch_message`, `fetch_attachment`, `search_mailbox` |
+| **mutating** | `create_folder`, `create_label`, `mark_read`, `mark_unread`, `add_labels` |
+| **destructive** | `move_emails`, `remove_labels`, `delete_folder`, `delete_label`, `revert_operations` |
+| **maintenance** | `verify_session` |
+
+**Change 1: `verify_connectivity` → `verify_session`.** The TypeScript tool tested IMAP connectivity by acquiring a connection from the pool and measuring round-trip latency. There is no IMAP pool in the Go version. The new `verify_session` instead:
+
+- Verifies the stored auth session is still valid (not expired or revoked)
+- Calls `client.GetUser()` as a lightweight authenticated round-trip
+- Returns the user's primary email and session expiry information
+- Lets agents check "is the connection working?" before attempting heavier operations
+
+The semantics are similar (health check), but the implementation is fundamentally different. The new name reflects this.
+
+**Change 2: `drain_connections` is dropped.** The TypeScript version drained the IMAP connection pool. There is no connection pool in the Go version — go-proton-api manages a single HTTP client internally. The maintenance category contains only `verify_session`.
+
+### Artwork to copy
+
+Copy these files from `~/Projects/proton-bridge-mcp/assets/` into `assets/` in the new repo. Same product, different implementation — keep the branding:
+
+- `icon.svg`
+- `small-icon.svg`
+- `logo.svg`
+- `icon-256.png`, `icon-64.png`, `icon-32.png`, `icon-16.png`
+
+### What to drop entirely
+
+- All TypeScript source under `src/`
+- `package.json`, `package-lock.json`, `node_modules/`
+- `tsconfig.json`, `tsconfig.test.json`, `jest.config.ts`
+- `eslint.config.js`, `.prettierrc`
+- `scripts/run_smoketest.sh`, `scripts/run_inspector.sh` (replaced by `go run ./cmd/smoketest`)
+- All TypeScript tests
+- `.release-it.json` (release-it is npm-based — replaced by `goreleaser`)
+
+### What to adapt, not drop
+
+- **`manifest.json`** — the MCPB format is a zip with a manifest. For the Go binary, the manifest references the compiled binary as the entrypoint instead of a Node.js script. Claude Desktop MCPB packaging is **retained** because it's the easiest install path for end users; only the manifest contents change. You will adapt this in Phase 2.
+
+---
+
+## Phase 0: Project Bootstrap
+
+**Goal:** A new GitHub repo with an empty Go project that builds and passes CI.
+
+### Tasks
+
+- [x] Create a new GitHub repo `proton-mail-mcp` (private initially; make public after Phase 2 release)
+- [x] Clone it locally to `~/Projects/proton-mail-mcp`
+- [x] Run `go mod init github.com/grover/proton-mail-mcp`
+- [x] Add base dependencies:
+  ```bash
+  go get github.com/ProtonMail/go-proton-api
+  go get github.com/modelcontextprotocol/go-sdk/mcp
+  go get github.com/spf13/cobra
+  go get github.com/joho/godotenv
+  ```
+- [ ] Create the directory layout:
+  ```
+  proton-mail-mcp/
+  ├── cmd/
+  │   └── proton-mail-mcp/
+  │       └── main.go         # Cobra root command
+  ├── internal/
+  │   ├── auth/               # Phase 1: SRP login, vault, refresh
+  │   ├── proton/             # Phase 2: ProtonClient wrapper, rate limit
+  │   ├── mcp/                # Phase 2: MCP server, tool registration
+  │   ├── ops/                # Phase 5: operation log, reversal specs
+  │   ├── tools/              # Phase 4+: tool handlers
+  │   └── audit/              # Phase 2: audit logger
+  ├── assets/                 # Copied from old repo
+  ├── docs/                   # Copied selectively from old repo
+  ├── .github/
+  │   └── workflows/
+  │       ├── ci.yml          # vet + lint + test + build
+  │       └── release.yml     # goreleaser, added in Phase 2
+  ├── .golangci.yml           # Linter config
+  ├── go.mod
+  ├── go.sum
+  ├── LICENSE                 # GPL-3.0 (matches go-proton-api license)
+  ├── README.md               # Minimal stub for now
+  ├── CLAUDE.md               # Adapted from old repo
+  └── CHANGELOG.md            # Empty [Unreleased] section
+  ```
+- [ ] Copy `assets/` from old repo
+- [ ] Copy `LICENSE` (GPL-3.0) — must match go-proton-api's license, the project is already GPL-anchored
+- [ ] Write minimal `cmd/proton-mail-mcp/main.go`:
+  ```go
+  package main
+
+  import (
+      "fmt"
+      "os"
+
+      "github.com/spf13/cobra"
+  )
+
+  var rootCmd = &cobra.Command{
+      Use:   "proton-mail-mcp",
+      Short: "MCP server for ProtonMail via go-proton-api",
+  }
+
+  func main() {
+      if err := rootCmd.Execute(); err != nil {
+          fmt.Fprintln(os.Stderr, err)
+          os.Exit(1)
+      }
+  }
+  ```
+- [ ] Configure `.golangci.yml` with sensible defaults: `errcheck`, `gosimple`, `govet`, `ineffassign`, `staticcheck`, `unused`, `gofmt`, `goimports`, `revive`
+- [ ] Create `.github/workflows/ci.yml`:
+  ```yaml
+  name: CI
+  on: [push, pull_request]
+  jobs:
+    test:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-go@v5
+          with: { go-version: '1.22' }
+        - run: go mod download
+        - run: go vet ./...
+        - uses: golangci/golangci-lint-action@v6
+          with: { version: latest }
+        - run: go test ./...
+        - run: go build ./...
+  ```
+- [ ] Adapt `CLAUDE.md` from the old repo following the conventions list above
+- [ ] Initial `CHANGELOG.md` with empty `[Unreleased]` section
+- [ ] Initial `README.md` with project description and "under active development" warning
+
+### Build tooling decision: no Makefile
+
+Makefiles are not idiomatic for Go projects. Use the `go` command directly for everything:
+
+- `go build ./...` — build all packages
+- `go test ./...` — run all tests
+- `go vet ./...` — static analysis
+- `golangci-lint run` — comprehensive linting
+- `go run ./cmd/proton-mail-mcp serve` — run the server in dev mode
+
+For complex multi-step tasks (smoke tests, releases), put the orchestration logic in a `cmd/<task>/main.go` file and invoke with `go run ./cmd/<task>`. This keeps everything in Go, avoids shell escaping, works cross-platform, and adds no dependencies.
+
+Examples in the new repo:
+- `cmd/proton-mail-mcp/main.go` — the main binary (login + serve subcommands)
+- `cmd/smoketest/main.go` — smoke test harness (added in Phase 3)
+
+There is no `Makefile`. There are no shell scripts in `scripts/`. Every developer task runs through `go run` or `go test`.
+
+### Verification
+
+- [ ] `go build ./...` succeeds with no warnings
+- [ ] `go vet ./...` produces no output
+- [ ] `golangci-lint run` produces no findings
+- [ ] CI workflow runs and passes on push
+- [ ] `go run ./cmd/proton-mail-mcp` prints help text
+- [ ] `git log --oneline` shows a clean initial commit + bootstrap commit
+
+### Commit
+
+```
+chore: bootstrap proton-mail-mcp project structure
+
+Initial Go module, directory layout, CI workflow, and adapted CLAUDE.md.
+Assets and core docs copied from proton-bridge-mcp.
+```
+
+---
+
+## Phase 1: Authentication MVP
+
+**Goal:** A working `proton-mail-mcp login` subcommand that authenticates against the real Proton API, stores the session encrypted on disk, and refreshes the token on subsequent runs.
+
+### Background
+
+Read [docs/proton/authentication-flows.md](proton/authentication-flows.md) section "Recommendation for MCP Server Auth" before starting. The recommended design is "first run interactive, steady state headless". This phase implements the first run.
+
+The reference implementation for SRP login + token storage is `~/Projects/proton-bridge/internal/bridge/user.go`, function `LoginFull` (lines 194-247). Read it. You will implement essentially the same flow, minus the GUI callback indirection.
+
+### Tasks
+
+- [ ] Create `internal/auth/login.go` with the login flow:
+  ```go
+  package auth
+
+  import (
+      "context"
+      "errors"
+      "fmt"
+
+      "github.com/ProtonMail/go-proton-api"
+  )
+
+  type Credentials struct {
+      Username string
+      Password string
+  }
+
+  type Session struct {
+      AuthUID      string
+      RefreshToken string
+      KeyPass      []byte // Salted mailbox password for key decryption
+      UserID       string
+      PrimaryEmail string
+  }
+
+  func Login(ctx context.Context, manager *proton.Manager, creds Credentials, getTOTP func() (string, error)) (*Session, error) {
+      client, auth, err := manager.NewClientWithLogin(ctx, creds.Username, []byte(creds.Password))
+      if err != nil {
+          return nil, fmt.Errorf("login failed: %w", err)
+      }
+
+      // Reject two-password mode — not supported in this server
+      if auth.PasswordMode == proton.TwoPasswordMode {
+          _ = client.AuthDelete(ctx)
+          return nil, errors.New("two-password mode is not supported by proton-mail-mcp; please use single-password mode")
+      }
+
+      // Handle 2FA if required
+      if auth.TwoFA.Enabled & proton.HasTOTP != 0 {
+          totp, err := getTOTP()
+          if err != nil {
+              _ = client.AuthDelete(ctx)
+              return nil, fmt.Errorf("TOTP required: %w", err)
+          }
+          if err := client.Auth2FA(ctx, proton.Auth2FAReq{TwoFactorCode: totp}); err != nil {
+              _ = client.AuthDelete(ctx)
+              return nil, fmt.Errorf("2FA failed: %w", err)
+          }
+      }
+
+      // FIDO2 not supported
+      if auth.TwoFA.Enabled & proton.HasFIDO2 != 0 && auth.TwoFA.Enabled & proton.HasTOTP == 0 {
+          _ = client.AuthDelete(ctx)
+          return nil, errors.New("FIDO2-only 2FA is not supported; please enable TOTP")
+      }
+
+      // Fetch user info and key salts
+      user, err := client.GetUser(ctx)
+      if err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("get user failed: %w", err)
+      }
+      salts, err := client.GetSalts(ctx)
+      if err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("get salts failed: %w", err)
+      }
+
+      // Salt the password to derive the key password
+      saltedKeyPass, err := salts.SaltForKey([]byte(creds.Password), user.Keys.Primary().ID)
+      if err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("salt for key failed: %w", err)
+      }
+
+      // Verify the key password actually unlocks the user's primary key
+      if _, err := user.Keys.Unlock(saltedKeyPass, nil); err != nil {
+          _ = client.AuthDelete(ctx)
+          return nil, fmt.Errorf("key unlock failed: %w", err)
+      }
+
+      return &Session{
+          AuthUID:      auth.UID,
+          RefreshToken: auth.RefreshToken,
+          KeyPass:      saltedKeyPass,
+          UserID:       user.ID,
+          PrimaryEmail: user.Email,
+      }, nil
+  }
+  ```
+- [ ] Create `internal/auth/vault.go` with AES-256-GCM encryption:
+  ```go
+  package auth
+
+  import (
+      "crypto/aes"
+      "crypto/cipher"
+      "crypto/rand"
+      "encoding/json"
+      "errors"
+      "io"
+      "os"
+      "path/filepath"
+  )
+
+  const vaultFileName = "session.enc"
+
+  // Save encrypts the session and writes it to disk
+  func SaveSession(s *Session, vaultDir string, encryptionKey []byte) error {
+      data, err := json.Marshal(s)
+      if err != nil {
+          return err
+      }
+      block, err := aes.NewCipher(encryptionKey)
+      if err != nil {
+          return err
+      }
+      gcm, err := cipher.NewGCM(block)
+      if err != nil {
+          return err
+      }
+      nonce := make([]byte, gcm.NonceSize())
+      if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+          return err
+      }
+      ciphertext := gcm.Seal(nonce, nonce, data, nil)
+      if err := os.MkdirAll(vaultDir, 0700); err != nil {
+          return err
+      }
+      return os.WriteFile(filepath.Join(vaultDir, vaultFileName), ciphertext, 0600)
+  }
+
+  // Load reads and decrypts the session from disk
+  func LoadSession(vaultDir string, encryptionKey []byte) (*Session, error) {
+      ciphertext, err := os.ReadFile(filepath.Join(vaultDir, vaultFileName))
+      if err != nil {
+          return nil, err
+      }
+      block, err := aes.NewCipher(encryptionKey)
+      if err != nil {
+          return nil, err
+      }
+      gcm, err := cipher.NewGCM(block)
+      if err != nil {
+          return nil, err
+      }
+      if len(ciphertext) < gcm.NonceSize() {
+          return nil, errors.New("vault file too short")
+      }
+      nonce := ciphertext[:gcm.NonceSize()]
+      ct := ciphertext[gcm.NonceSize():]
+      plaintext, err := gcm.Open(nil, nonce, ct, nil)
+      if err != nil {
+          return nil, err
+      }
+      var s Session
+      if err := json.Unmarshal(plaintext, &s); err != nil {
+          return nil, err
+      }
+      return &s, nil
+  }
+  ```
+- [ ] Create `internal/auth/keyderive.go` to derive the vault encryption key. Use a combination of machine ID + a random salt stored alongside the vault. This protects against the vault file being copied to another machine. (Bridge does something similar with platform keychain integration; for simplicity, derive from `/etc/machine-id` on Linux, system UUID on macOS, machine GUID on Windows. Document this isn't bulletproof — it's a deterrent against accidental disclosure.)
+- [ ] Create `internal/auth/refresh.go`:
+  ```go
+  package auth
+
+  import (
+      "context"
+      "fmt"
+
+      "github.com/ProtonMail/go-proton-api"
+  )
+
+  // Refresh creates a fresh authenticated client from a stored session
+  func Refresh(ctx context.Context, manager *proton.Manager, s *Session) (*proton.Client, *Session, error) {
+      client, newAuth, err := manager.NewClientWithRefresh(ctx, s.AuthUID, s.RefreshToken)
+      if err != nil {
+          return nil, nil, fmt.Errorf("refresh failed: %w", err)
+      }
+      // Update session with new tokens (refresh tokens rotate)
+      s.AuthUID = newAuth.UID
+      s.RefreshToken = newAuth.RefreshToken
+      return client, s, nil
+  }
+  ```
+- [ ] Add the `login` Cobra subcommand to `cmd/proton-mail-mcp/main.go`:
+  ```go
+  var loginCmd = &cobra.Command{
+      Use:   "login",
+      Short: "Authenticate with Proton and store an encrypted session",
+      RunE:  runLogin,
+  }
+
+  func runLogin(cmd *cobra.Command, args []string) error {
+      // Prompt for credentials via stdin
+      // Call auth.Login with a TOTP callback that prompts via stdin
+      // Save session via auth.SaveSession
+      // Print success message with primary email
+  }
+  ```
+- [ ] Use `golang.org/x/term` for password input that doesn't echo to the terminal
+- [ ] Document failure modes in the error messages: two-password mode, FIDO2-only, human verification required (CAPTCHA), TOTP required but no TTY
+
+### Verification
+
+- [ ] `go run ./cmd/proton-mail-mcp login` prompts for username, password (hidden), TOTP if enabled
+- [ ] On success, prints "Logged in as user@protonmail.com" and creates `~/.proton-mail-mcp/session.enc`
+- [ ] The session file is mode 0600 and unreadable as plain text
+- [ ] Running `login` again overwrites the previous session
+- [ ] If Proton requires CAPTCHA (HV), the command exits with a clear error message instructing the user to wait or change network
+- [ ] If the account uses two-password mode, the command exits with a clear error
+- [ ] Unit tests for `vault.go` (encrypt/decrypt round-trip, tamper detection)
+- [ ] Unit tests for the Cobra command structure (cobra makes this easy)
+
+### Commit
+
+```
+feat: add login subcommand with SRP auth and encrypted session vault
+
+Implements interactive login via go-proton-api SRP. Stores AuthUID,
+RefreshToken, and salted key password in AES-256-GCM encrypted vault
+at ~/.proton-mail-mcp/session.enc. Supports TOTP 2FA via stdin prompt.
+
+Two-password mode and FIDO2-only 2FA are explicitly rejected.
+CAPTCHA / human verification is not handled — user must wait or
+change network.
+```
+
+---
+
+## Phase 2: MCP Server Skeleton + Distribution + First Release
+
+**Goal:** A working `proton-mail-mcp serve` subcommand that loads the encrypted session, refreshes the token, and exposes the `verify_session` tool over MCP STDIO. Plus full distribution: goreleaser, MCPB packaging, GitHub Releases. First installable artifact.
+
+### Background
+
+Read the Go MCP SDK documentation at `github.com/modelcontextprotocol/go-sdk` (the README and examples). The key concepts are `mcp.NewServer`, tool registration with `mcp.Tool`, and STDIO transport via `mcp.NewStdioServerTransport`.
+
+This phase intentionally has only one tool (`verify_session`) so that all the infrastructure (server skeleton, audit logging, rate limiting, distribution, MCPB packaging, releases) is built and proven before any real tool work begins.
+
+### Tasks
+
+#### Server skeleton
+
+- [ ] Create `internal/proton/client.go` — a thin wrapper around `proton.Client` that adds:
+  - Rate limit handling (retry on 429 with `Retry-After`)
+  - Structured error mapping (convert go-proton-api errors to MCP-friendly errors)
+  - A reference to the `AuditLogger`
+- [ ] Create `internal/audit/logger.go` — JSONL audit log to a file:
+  ```go
+  type AuditEntry struct {
+      Timestamp time.Time `json:"ts"`
+      Operation string    `json:"op"`
+      Input     any       `json:"input,omitempty"`
+      Duration  string    `json:"duration"`
+      Error     string    `json:"error,omitempty"`
+  }
+
+  type AuditLogger interface {
+      Log(entry AuditEntry)
+      Close() error
+  }
+  ```
+- [ ] Implement `Audited` generic helper in `internal/audit/middleware.go` per the pattern shown above
+- [ ] Create `internal/proton/ratelimit.go` — wrap API calls in a retry loop:
+  ```go
+  func WithRateLimit[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+      const maxRetries = 5
+      var zero T
+      for attempt := 0; attempt <= maxRetries; attempt++ {
+          result, err := fn()
+          if err == nil {
+              return result, nil
+          }
+          var apiErr *proton.APIError
+          if errors.As(err, &apiErr) && apiErr.Status == 429 {
+              retryAfter := parseRetryAfter(apiErr) // from header or default
+              select {
+              case <-ctx.Done():
+                  return zero, ctx.Err()
+              case <-time.After(retryAfter):
+                  continue
+              }
+          }
+          return zero, err
+      }
+      return zero, errors.New("rate limit exceeded after retries")
+  }
+  ```
+- [ ] Create `internal/mcp/server.go` — initialize the MCP server, register tools:
+  ```go
+  package mcp
+
+  import (
+      "context"
+
+      "github.com/modelcontextprotocol/go-sdk/mcp"
+      "github.com/grover/proton-mail-mcp/internal/proton"
+  )
+
+  func NewServer(client *proton.Client) *mcp.Server {
+      s := mcp.NewServer("proton-mail-mcp", "0.1.0")
+      RegisterVerifySession(s, client)
+      return s
+  }
+  ```
+- [ ] Create `internal/mcp/tools/verify_session.go` — the first tool:
+  ```go
+  package tools
+
+  import (
+      "context"
+
+      "github.com/modelcontextprotocol/go-sdk/mcp"
+      "github.com/grover/proton-mail-mcp/internal/proton"
+  )
+
+  type VerifySessionResult struct {
+      Email           string `json:"email"`
+      UserID          string `json:"userId"`
+      SessionValid    bool   `json:"sessionValid"`
+  }
+
+  func RegisterVerifySession(s *mcp.Server, client *proton.Client) {
+      s.AddTool(mcp.Tool{
+          Name:        "verify_session",
+          Description: "Verify the Proton API session is valid. Returns the authenticated user's email.",
+          // Annotations: ReadOnly hint, no destructive
+      }, func(ctx context.Context, _ struct{}) (VerifySessionResult, error) {
+          user, err := client.GetUser(ctx)
+          if err != nil {
+              return VerifySessionResult{SessionValid: false}, err
+          }
+          return VerifySessionResult{
+              Email:        user.Email,
+              UserID:       user.ID,
+              SessionValid: true,
+          }, nil
+      })
+  }
+  ```
+- [ ] Add the `serve` Cobra subcommand to `cmd/proton-mail-mcp/main.go`:
+  ```go
+  var serveCmd = &cobra.Command{
+      Use:   "serve",
+      Short: "Start the MCP server (STDIO transport)",
+      RunE:  runServe,
+  }
+
+  func runServe(cmd *cobra.Command, args []string) error {
+      ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+      defer cancel()
+
+      // Load session from vault
+      session, err := auth.LoadSession(vaultDir, encryptionKey)
+      if err != nil {
+          return fmt.Errorf("load session: %w (run 'proton-mail-mcp login' first)", err)
+      }
+
+      // Refresh token
+      manager := proton.New(...)
+      client, session, err := auth.Refresh(ctx, manager, session)
+      if err != nil {
+          return fmt.Errorf("refresh failed: %w", err)
+      }
+      // Save updated session (refresh tokens rotate)
+      _ = auth.SaveSession(session, vaultDir, encryptionKey)
+
+      // Wrap client with rate limit + audit
+      protonClient := proton.NewClient(client, auditLogger)
+
+      // Build MCP server
+      mcpServer := mcp.NewServer(protonClient)
+
+      // Run on STDIO transport
+      transport := mcp.NewStdioServerTransport()
+      return mcpServer.Serve(ctx, transport)
+  }
+  ```
+
+#### Distribution
+
+- [ ] Create `.goreleaser.yml`:
+  ```yaml
+  project_name: proton-mail-mcp
+  builds:
+    - main: ./cmd/proton-mail-mcp
+      binary: proton-mail-mcp
+      env: [CGO_ENABLED=0]
+      goos: [linux, darwin, windows]
+      goarch: [amd64, arm64]
+      ignore:
+        - { goos: windows, goarch: arm64 }
+  archives:
+    - format: tar.gz
+      format_overrides:
+        - { goos: windows, format: zip }
+  release:
+    github:
+      owner: grover
+      name: proton-mail-mcp
+  changelog:
+    sort: asc
+  ```
+- [ ] Create `.github/workflows/release.yml`:
+  ```yaml
+  name: Release
+  on:
+    push:
+      tags: ['v*']
+  jobs:
+    goreleaser:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+          with: { fetch-depth: 0 }
+        - uses: actions/setup-go@v5
+          with: { go-version: '1.22' }
+        - uses: goreleaser/goreleaser-action@v6
+          with:
+            args: release --clean
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build MCPB package
+          run: go run ./cmd/build-mcpb
+        - name: Upload MCPB to release
+          # ... attach proton-mail-mcp.mcpb to the release
+  ```
+
+#### MCPB packaging
+
+- [ ] Create `manifest.json` in the repo root, adapted from the old repo. Reference the Go binary instead of a Node.js script. Read the old `manifest.json` first to understand the schema.
+- [ ] Create `cmd/build-mcpb/main.go` — a Go program that builds the `.mcpb` zip:
+  - Reads `manifest.json`
+  - Includes `proton-mail-mcp` (the compiled binary for the current platform)
+  - Includes `assets/icon.svg` and other assets referenced in the manifest
+  - Zips everything to `proton-mail-mcp.mcpb`
+- [ ] Document MCPB installation in `README.md`
+
+#### Documentation
+
+- [ ] Update `README.md` with:
+  - Project description
+  - Install instructions (download from releases, or `go install`)
+  - Quickstart (`login`, then `serve`)
+  - List of tools (just `verify_session` for now)
+  - Note that this is v0.1.0 — feature parity work in progress
+- [ ] Add `[v0.1.0]` section to `CHANGELOG.md`
+- [ ] Document the configuration model in `docs/configuration.md` (currently just the vault location)
+
+### Verification
+
+- [ ] `go run ./cmd/proton-mail-mcp serve` (after `login`) starts the server, blocks on stdin
+- [ ] Connect via the MCP Inspector (`npx @modelcontextprotocol/inspector`) using STDIO transport pointed at the serve command
+- [ ] `verify_session` appears in the tool list
+- [ ] Calling `verify_session` returns the real user's email
+- [ ] Audit log file is created and contains a JSONL entry per tool call
+- [ ] `goreleaser release --snapshot --clean` produces binaries for all platforms in `dist/`
+- [ ] `go run ./cmd/build-mcpb` produces a valid `proton-mail-mcp.mcpb` file
+- [ ] Installing the MCPB in Claude Desktop makes `verify_session` available
+- [ ] CI passes
+- [ ] Tag `v0.1.0` and verify the release workflow produces a GitHub Release with all binaries and the MCPB
+
+### Commit and release
+
+```
+feat: add MCP server skeleton with verify_session and full distribution
+
+- serve subcommand starts the MCP server on STDIO
+- verify_session tool returns authenticated user info
+- Rate limit handling via retry on 429 with Retry-After
+- JSONL audit logger
+- goreleaser config for cross-platform binaries
+- Adapted manifest.json + build-mcpb for Claude Desktop packaging
+- Tag v0.1.0
+```
+
+---
+
+## Phase 3: Smoke Testing Infrastructure
+
+**Goal:** A reliable smoke test harness that runs against both the real Proton API (interactive) and an in-process fake server (automated, headless, CI-suitable).
+
+### Background
+
+Read `~/Projects/proton-bridge/tests/api_test.go` to see how Bridge uses the `go-proton-api/server.Server` fake API server for its own integration tests. The fake server is part of the go-proton-api package and exposes the full API surface as an in-process HTTP server with a deterministic dataset.
+
+### Tasks
+
+- [ ] Create `cmd/smoketest/main.go` with two modes:
+  ```go
+  package main
+
+  import (
+      "flag"
+      "log"
+  )
+
+  func main() {
+      fakeMode := flag.Bool("fake", false, "Run against in-process fake server instead of real Proton API")
+      flag.Parse()
+
+      if *fakeMode {
+          runFakeMode()
+      } else {
+          runRealMode()
+      }
+  }
+  ```
+
+#### Mode A: Real account
+
+- [ ] `go run ./cmd/smoketest` (no `--fake`):
+  - Pre-flight: kill any process holding the Inspector port (use `lsof -ti tcp:6277 | xargs kill` style logic from the old repo's `run_smoketest.sh`)
+  - Load `.env` via `github.com/joho/godotenv`
+  - Verify the user has run `proton-mail-mcp login` previously (check vault file exists). **Do not** prompt for TOTP from the smoke test command — that's a manual one-time setup step.
+  - Start `proton-mail-mcp serve` as a subprocess
+  - Start the MCP Inspector pointed at the serve subprocess
+  - Print connection details to stdout
+  - Wait for SIGINT to clean up
+
+#### Mode B: Fake server (CI-suitable)
+
+- [ ] `go run ./cmd/smoketest --fake`:
+  - Spin up `go-proton-api/server.Server` in-process
+  - Pre-populate it with deterministic test data:
+    - A test user with a known password
+    - Several labels (system + custom)
+    - Several folders
+    - Messages in INBOX with a mix of: read/unread, with/without attachments, in various labels
+  - Authenticate against the fake server (using the test password)
+  - Start the MCP server pointing at the fake server URL
+  - Run scripted scenarios as direct MCP protocol calls (no Inspector UI)
+  - Assert expected outcomes
+  - Tear down everything cleanly
+  - Exit non-zero on any assertion failure
+
+- [ ] Create `internal/testfixtures/fakeserver.go` with helpers to set up the fake server with deterministic data
+- [ ] Create `internal/testfixtures/scenarios.go` with the scripted scenarios per phase
+
+### Scenarios per phase
+
+The fake-server scenarios grow as each phase adds tools:
+
+| Phase | Scenarios |
+|---|---|
+| 3 (this phase) | `verify_session` returns the test user's email — proves end-to-end harness works |
+| 4 | + `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`, verify attachment metadata in summaries |
+| 5 | + `mark_read` an email, verify it's read, `revert_operations`, verify it's unread again |
+| 6 | + `create_folder` with a path, verify it appears in `get_folders`, `delete_folder`, verify it's gone |
+| 7 | + `move_emails` from INBOX to a folder, verify; `add_labels` then `remove_labels`, verify |
+| 8 | + `fetch_message` returns a body; `fetch_attachment` returns base64 content |
+
+`verify_session` is included in **every** phase's scenarios as a sanity check.
+
+### Tasks for documentation
+
+- [ ] Create `docs/smoke-tests.md` listing all current scenarios
+- [ ] Update `README.md` with the smoke test instructions
+- [ ] Add a CI job that runs `go run ./cmd/smoketest --fake` on every push
+
+### Verification
+
+- [ ] `go run ./cmd/smoketest --fake` runs end-to-end against the fake server in <10 seconds, exits 0
+- [ ] CI runs the fake-mode smoke test and reports pass/fail
+- [ ] `go run ./cmd/smoketest` (real mode) starts the Inspector, connects to the real Proton account, and `verify_session` returns the user's email
+- [ ] The fake server scenarios are documented in `docs/smoke-tests.md`
+
+### Commit
+
+```
+test: add smoke test infrastructure with fake server automation
+
+Mode A: interactive harness against real Proton account via Inspector.
+Mode B: headless scripted scenarios against go-proton-api fake server.
+CI runs Mode B on every push.
+```
+
+---
+
+## Phase 4: Read Tools (with redesigned summaries from day one)
+
+**Goal:** Ship the four basic read tools (`get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries`) with attachment metadata in summaries from the start. Release v0.2.0.
+
+### Background
+
+The TypeScript implementation has open issue #57 to move attachment metadata from `fetch_message` into `EmailSummary`. The Go port should ship the redesigned shape from the very first read tool — no later breaking change.
+
+Read `~/Projects/proton-bridge/internal/services/imapservice/connector.go` for how Bridge calls `client.GetMessageMetadataPage` and similar methods. The pagination patterns and label filtering are the relevant references.
+
+### Tasks
+
+#### Types
+
+- [ ] Create `internal/types/email.go` with the data types:
+  ```go
+  package types
+
+  type EmailID = string // ProtonMail message ID, opaque
+
+  type AttachmentMetadata struct {
+      Filename    string `json:"filename"`
+      Size        int    `json:"size"`
+      ContentType string `json:"contentType"`
+      PartID      string `json:"partId"`
+  }
+
+  type EmailSummary struct {
+      ID          EmailID              `json:"id"`
+      Subject     string               `json:"subject"`
+      From        string               `json:"from"`
+      To          []string             `json:"to"`
+      Date        time.Time            `json:"date"`
+      Unread      bool                 `json:"unread"`
+      LabelIDs    []string             `json:"labelIds"`
+      Attachments []AttachmentMetadata `json:"attachments,omitempty"`
+  }
+
+  type FolderInfo struct {
+      ID           string `json:"id"`
+      Path         string `json:"path"`
+      MessageCount int    `json:"messageCount"`
+      UnreadCount  int    `json:"unreadCount"`
+  }
+
+  type LabelInfo struct {
+      // No path, no ID — labels expose name only
+      Name         string `json:"name"`
+      MessageCount int    `json:"messageCount"`
+      UnreadCount  int    `json:"unreadCount"`
+  }
+  ```
+  Note: `LabelInfo` deliberately omits the label ID. The MCP server uses label names externally and resolves them to IDs internally. This matches the TypeScript design.
+
+#### Tool result types
+
+- [ ] Create `internal/mcp/results.go` with the generic result wrappers:
+  ```go
+  type ToolStatus string
+
+  const (
+      StatusSucceeded ToolStatus = "succeeded"
+      StatusPartial   ToolStatus = "partial"
+      StatusFailed    ToolStatus = "failed"
+  )
+
+  type SingleToolResult[T any] struct {
+      Status ToolStatus `json:"status"`
+      Data   T          `json:"data"`
+  }
+
+  type ListToolResult[T any] struct {
+      Status ToolStatus `json:"status"`
+      Items  []T        `json:"items"`
+  }
+
+  type BatchItemResult[T any] struct {
+      ID     string  `json:"id"`
+      Status string  `json:"status"`
+      Data   *T      `json:"data,omitempty"`
+      Error  *string `json:"error,omitempty"`
+  }
+
+  type BatchToolResult[T any] struct {
+      Status ToolStatus            `json:"status"`
+      Items  []BatchItemResult[T]  `json:"items"`
+  }
+  ```
+
+#### Tools
+
+- [ ] Implement `internal/mcp/tools/get_folders.go`:
+  - Calls `client.GetLabels()` (which returns ALL labels including system, folder, label)
+  - Filters to `LabelTypeFolder` + system folders (Inbox, Sent, Drafts, Trash, etc.)
+  - Maps each to `FolderInfo` with its path
+  - Returns `ListToolResult[FolderInfo]`
+- [ ] Implement `internal/mcp/tools/get_labels.go`:
+  - Calls `client.GetLabels()`
+  - Filters to `LabelTypeLabel` only
+  - Maps each to `LabelInfo` (name only — no ID, no path)
+  - Returns `ListToolResult[LabelInfo]`
+- [ ] Implement `internal/mcp/tools/list_mailbox.go`:
+  - Input: `{ mailbox: string, limit: int, offset: int }`
+  - Resolves the mailbox name to a label ID (system folders use known IDs; user folders/labels via `GetLabels()` lookup)
+  - Calls `client.GetMessageMetadataPage()` with pagination
+  - Maps each `proton.MessageMetadata` to `EmailSummary`, including attachment metadata from `AttachmentInfo`
+  - Returns `ListToolResult[EmailSummary]`
+- [ ] Implement `internal/mcp/tools/fetch_summaries.go`:
+  - Input: `{ ids: []string }`
+  - Calls `client.GetMessageMetadataPage()` filtered by IDs
+  - Same mapping as `list_mailbox`
+  - Returns `ListToolResult[EmailSummary]`
+- [ ] Register all four tools in `internal/mcp/server.go`
+- [ ] Add unit tests for the type mapping (proton.MessageMetadata -> EmailSummary)
+
+#### Tests
+
+- [ ] Add scenarios to `cmd/smoketest/main.go` Mode B:
+  - List folders, assert INBOX is present
+  - List labels, assert no IDs leak in the output
+  - List INBOX, assert at least one summary has attachment metadata
+  - Fetch summaries by ID, assert same shape as list_mailbox
+
+#### Documentation
+
+- [ ] Add tool entries to `docs/tools/README.md`
+- [ ] Update `[Unreleased]` in `CHANGELOG.md`
+- [ ] Update `README.md` to list the new tools
+
+### Verification
+
+- [ ] All four tools work via the MCP Inspector against a real account
+- [ ] Fake-server smoke test passes for Phase 4 scenarios
+- [ ] `LabelInfo` JSON output contains no `id` or `path` field — only `name`, `messageCount`, `unreadCount`
+- [ ] Summaries with attachments have populated `attachments` arrays
+- [ ] Tag `v0.2.0` and release
+
+### Commit and release
+
+```
+feat: add read tools (get_folders, get_labels, list_mailbox, fetch_summaries)
+
+EmailSummary includes attachment metadata from day one (issue #57 from
+the TypeScript repo). LabelInfo exposes name only — no IDs or paths.
+
+Tag v0.2.0
+```
+
+---
+
+## Phase 5: Operation Log + First Reversible Tools
+
+**Goal:** Build the operation log infrastructure and ship the simplest reversible tools (`mark_read`, `mark_unread`) plus `revert_operations`. Release v0.3.0.
+
+### Background
+
+Read [docs/impl/operation-log-revert.md](impl/operation-log-revert.md) for the design rationale. Translate the TypeScript snippets to Go. The Go version is structurally simpler because there's no IMAP UID instability — MessageIDs are stable, so the UID rewriting chain from the TypeScript implementation doesn't apply.
+
+### Tasks
+
+#### Operation log
+
+- [ ] Create `internal/ops/log.go`:
+  ```go
+  package ops
+
+  import (
+      "sync"
+      "time"
+  )
+
+  type ReversalSpec interface {
+      reversalSpec() // marker method
+  }
+
+  type NoopReversal struct{}
+  func (NoopReversal) reversalSpec() {}
+
+  type MarkReadReversal struct {
+      IDs []string
+  }
+  func (MarkReadReversal) reversalSpec() {}
+
+  type MarkUnreadReversal struct {
+      IDs []string
+  }
+  func (MarkUnreadReversal) reversalSpec() {}
+
+  // ... more reversal types added in later phases
+
+  type OperationRecord struct {
+      ID        int64
+      Tool      string
+      Reversal  ReversalSpec
+      Timestamp time.Time
+  }
+
+  const maxLogSize = 100
+
+  type Log struct {
+      mu      sync.Mutex
+      seq     int64
+      records []OperationRecord
+  }
+
+  func NewLog() *Log {
+      return &Log{records: make([]OperationRecord, 0, maxLogSize)}
+  }
+
+  func (l *Log) Push(tool string, reversal ReversalSpec) int64 {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      l.seq++
+      record := OperationRecord{
+          ID:        l.seq,
+          Tool:      tool,
+          Reversal:  reversal,
+          Timestamp: time.Now(),
+      }
+      l.records = append(l.records, record)
+      if len(l.records) > maxLogSize {
+          l.records = l.records[len(l.records)-maxLogSize:]
+      }
+      return record.ID
+  }
+
+  // GetFrom returns records from the given ID forward, in reverse-chronological order
+  func (l *Log) GetFrom(id int64) []OperationRecord {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      var found []OperationRecord
+      for _, r := range l.records {
+          if r.ID >= id {
+              found = append(found, r)
+          }
+      }
+      // Reverse for chronological-newest-first
+      for i, j := 0, len(found)-1; i < j; i, j = i+1, j-1 {
+          found[i], found[j] = found[j], found[i]
+      }
+      return found
+  }
+
+  func (l *Log) Has(id int64) bool {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      for _, r := range l.records {
+          if r.ID == id {
+              return true
+          }
+      }
+      return false
+  }
+
+  func (l *Log) Clear() {
+      l.mu.Lock()
+      defer l.mu.Unlock()
+      l.records = l.records[:0]
+  }
+  ```
+
+#### Tracked middleware
+
+- [ ] Create `internal/ops/middleware.go`:
+  ```go
+  // Tracked wraps a tool call and records its reversal in the operation log on success.
+  // The buildReversal callback receives the result and returns either a reversal spec
+  // or NoopReversal (for no-op cases like marking an already-read email as read).
+  func Tracked[T any](
+      log *Log,
+      tool string,
+      fn func() (T, error),
+      buildReversal func(T) ReversalSpec,
+  ) (T, int64, error) {
+      result, err := fn()
+      if err != nil {
+          var zero T
+          return zero, 0, err
+      }
+      reversal := buildReversal(result)
+      opID := log.Push(tool, reversal)
+      return result, opID, nil
+  }
+
+  // IrreversibleWhen clears the entire log if the predicate returns true after success.
+  // Used by destructive operations like delete_folder where reversal of prior operations
+  // becomes impossible.
+  func IrreversibleWhen[T any](
+      log *Log,
+      fn func() (T, error),
+      shouldClear func(T) bool,
+  ) (T, error) {
+      result, err := fn()
+      if err == nil && shouldClear(result) {
+          log.Clear()
+      }
+      return result, err
+  }
+  ```
+
+#### Tools
+
+- [ ] Implement `internal/mcp/tools/mark_read.go`:
+  - Input: `{ ids: []string }`
+  - Idempotency: fetch metadata first, only mark unread emails as read
+  - Call `client.MarkMessagesRead(ctx, ids...)`
+  - Build reversal: `MarkReadReversal{IDs: actuallyChangedIDs}` (or NoopReversal if nothing changed)
+  - Return `BatchToolResult[MarkReadResult]` with `operationId`
+- [ ] Implement `internal/mcp/tools/mark_unread.go` — same pattern, inverted
+- [ ] Implement `internal/mcp/tools/revert_operations.go`:
+  - Input: `{ operationId: int64 }`
+  - Validates the operation ID exists in the log (else `UNKNOWN_OPERATION_ID`)
+  - Walks log from the given ID forward in reverse-chronological order
+  - For each record, executes the reversal:
+    - `MarkReadReversal` -> `client.MarkMessagesUnread(ids)`
+    - `MarkUnreadReversal` -> `client.MarkMessagesRead(ids)`
+    - `NoopReversal` -> do nothing
+  - Returns `RevertResult` with per-step status
+- [ ] Wire `mark_read` and `mark_unread` to use `Tracked` middleware
+
+#### Tests
+
+- [ ] Add scenarios to fake-server smoke test:
+  - Mark an unread email as read, verify it's read
+  - Capture the operationId from the response
+  - Call `revert_operations` with that ID
+  - Verify the email is unread again
+  - Mark an already-read email as read, verify NoopReversal was recorded
+
+#### Documentation
+
+- [ ] Document the operation log pattern in `docs/impl/operation-log-revert.md` (port from TS version with Go snippets)
+- [ ] Add tool entries to `docs/tools/README.md`
+- [ ] Update `[Unreleased]` in `CHANGELOG.md`
+
+### Verification
+
+- [ ] Mark/unmark round-trip via the Inspector
+- [ ] Revert restores state
+- [ ] Idempotency: marking an already-read email as read records a NoopReversal
+- [ ] Fake-server smoke test passes
+- [ ] Tag `v0.3.0` and release
+
+### Commit and release
+
+```
+feat: add operation log + mark_read/mark_unread + revert_operations
+
+Implements the operation log ring buffer (100 entries, monotonic IDs)
+and the Tracked/IrreversibleWhen middleware helpers. mark_read and
+mark_unread are the first reversible tools, with idempotency-aware
+no-op detection.
+
+Tag v0.3.0
+```
+
+---
+
+## Phase 6: Folder/Label Management
+
+**Goal:** Ship `create_folder`, `create_label`, `delete_folder`, `delete_label`. Release v0.4.0.
+
+### Tasks
+
+- [ ] Add reversal types to `internal/ops/log.go`:
+  ```go
+  type CreateFolderReversal struct {
+      Path string
+  }
+  func (CreateFolderReversal) reversalSpec() {}
+
+  type CreateLabelReversal struct {
+      Name string
+  }
+  func (CreateLabelReversal) reversalSpec() {}
+  ```
+- [ ] Implement `internal/mcp/tools/create_folder.go`:
+  - Input: `{ path: string }`
+  - Validate path starts with `Folders/` and is non-trivial
+  - Call `client.CreateLabel(LabelTypeFolder, ...)` with parent ID resolution for nested paths (see Bridge's `createFolder` in `connector.go` for reference)
+  - On success: `CreateFolderReversal{Path: path}` for the operation log
+  - Return `SingleToolResult[CreateFolderResult]` with `{ path, created }`
+  - Idempotency: if the folder already exists, return `{ created: false }` and `NoopReversal`
+- [ ] Implement `internal/mcp/tools/create_label.go`:
+  - Input: `{ name: string }`
+  - Validate name does not contain `/`
+  - Call `client.CreateLabel(LabelTypeLabel, name)` (no parent — labels are flat)
+  - On success: `CreateLabelReversal{Name: name}`
+  - Return `{ name, created }` (NOT `path` — see [docs/impl/label-handling.md](impl/label-handling.md))
+  - Idempotency: if the label already exists, return `{ created: false }` and `NoopReversal`
+- [ ] Implement `internal/mcp/tools/delete_folder.go`:
+  - Input: `{ path: string }`
+  - Validate path starts with `Folders/`
+  - Reject if it's a special-use folder
+  - Call `client.DeleteLabel(folderID)`
+  - Use `IrreversibleWhen` middleware: when `deleted == true`, clear the entire operation log
+  - Return `{ path, deleted }`
+  - Idempotency: if the folder doesn't exist, return `{ deleted: false }` (do not clear log)
+- [ ] Implement `internal/mcp/tools/delete_label.go`:
+  - Input: `{ name: string }`
+  - Resolve name -> label ID
+  - Call `client.DeleteLabel(labelID)`
+  - Use `IrreversibleWhen` middleware
+  - Return `{ name, deleted }`
+- [ ] Add reversal execution for `CreateFolderReversal` and `CreateLabelReversal` in `revert_operations`:
+  - `CreateFolderReversal{Path}` -> `delete_folder(path)`
+  - `CreateLabelReversal{Name}` -> `delete_label(name)`
+- [ ] Add scenarios to fake-server smoke test:
+  - Create a folder, assert it appears in `get_folders`
+  - Delete it, assert it's gone
+  - Create a label, assert it appears in `get_labels`
+  - Delete it
+  - Create-then-revert: verify the folder/label is deleted by the revert
+
+### Documentation
+
+- [ ] Tool entries in `docs/tools/README.md`
+- [ ] CHANGELOG entry
+
+### Verification
+
+- [ ] All four tools work via Inspector
+- [ ] Fake-server smoke test passes
+- [ ] Idempotency verified
+- [ ] `delete_folder` clearing the log is verified by attempting a revert after a delete (should fail with UNKNOWN_OPERATION_ID)
+- [ ] Tag `v0.4.0` and release
+
+### Commit
+
+```
+feat: add folder/label CRUD tools
+
+create_folder, create_label, delete_folder, delete_label.
+Idempotent — repeated calls are no-ops. delete_folder and delete_label
+are IrreversibleWhen, clearing the operation log on actual deletion.
+
+Tag v0.4.0
+```
+
+---
+
+## Phase 7: Email Movement and Labels
+
+**Goal:** Ship `move_emails`, `add_labels`, `remove_labels`. Release v0.5.0.
+
+### Background
+
+Read `~/Projects/proton-bridge/internal/services/imapservice/connector.go` `MoveMessages` (around line 506) for the asymmetric label/folder MOVE logic. The bridge handles:
+- Moving between labels: label destination, unlabel source
+- Moving label -> folder: label destination, unlabel source
+- Moving folder -> label: label destination, source stays (this is unusual!)
+- Moving folder -> folder: relies on `shouldExpungeOldLocation` flag
+
+Your Go MCP version doesn't need to mirror exactly because it's not constrained by IMAP semantics. But the underlying API calls (`client.LabelMessages`, `client.UnlabelMessages`) are the same.
+
+### Tasks
+
+- [ ] Add reversal types:
+  ```go
+  type MoveBatchReversal struct {
+      Moves []struct {
+          IDs       []string
+          FromLabel string
+          ToLabel   string
+      }
+  }
+
+  type AddLabelsReversal struct {
+      IDs       []string
+      LabelName string
+  }
+
+  type RemoveLabelsReversal struct {
+      IDs       []string
+      LabelName string
+  }
+  ```
+- [ ] Implement `internal/mcp/tools/move_emails.go`:
+  - Input: `{ ids: []string, targetMailbox: string }`
+  - Resolve target mailbox name to label ID
+  - Group input emails by their current label (need to fetch current state)
+  - For each source label, call `client.LabelMessages(ids, targetID)` then `client.UnlabelMessages(ids, sourceID)`
+  - Build reversal: swap source/target for each group
+  - Return `BatchToolResult[MoveResult]` with `operationId`
+- [ ] Implement `internal/mcp/tools/add_labels.go`:
+  - Input: `{ ids: []string, labelNames: []string }`
+  - Resolve each label name to ID
+  - Call `client.LabelMessages(ids, labelID)` for each label
+  - **Response shape: `{ labelName, applied: bool }`** — no path, no IDs
+  - Return `BatchToolResult` with per-email per-label results
+  - Reversal: `RemoveLabelsReversal{IDs, LabelName}` for each successfully applied label
+- [ ] Implement `internal/mcp/tools/remove_labels.go`:
+  - Input: `{ ids: []string, labelNames: []string }`
+  - Resolve each label name to ID
+  - Call `client.UnlabelMessages(ids, labelID)` for each label
+  - Response: `{ labelName, removed: bool }`
+  - Reversal: `AddLabelsReversal{IDs, LabelName}`
+- [ ] Implement reversal execution for the new reversal types
+- [ ] Add fake-server smoke test scenarios:
+  - Move email INBOX -> Folders/Test, verify
+  - Move back via revert, verify
+  - Add label, verify it's applied (no path leaks in response!)
+  - Remove label, verify
+  - Round-trip add/remove via revert
+
+### Documentation
+
+- [ ] Tool entries in `docs/tools/README.md` — emphasize no-leak rule for `add_labels` response
+- [ ] CHANGELOG entry — explicitly mention this fixes the TS issue #54 (`add_labels` path leakage) by design
+
+### Verification
+
+- [ ] All three tools work via Inspector
+- [ ] `add_labels` response contains `labelName` and `applied`, never `labelPath` or `newId`
+- [ ] Fake-server smoke test passes
+- [ ] Tag `v0.5.0` and release
+
+### Commit
+
+```
+feat: add move_emails, add_labels, remove_labels
+
+add_labels response uses { labelName, applied } — no IMAP path or
+copy UID leakage (fixes TS issue #54 by design). All three tools are
+fully reversible via revert_operations.
+
+Tag v0.5.0
+```
+
+---
+
+## Phase 8: Message Body, Search, and Attachment Tools
+
+**Goal:** Ship `fetch_message` (body-only, redesigned per TS issue #58), `fetch_attachment`, `search_mailbox`. Release v0.6.0.
+
+### Background
+
+This is the first phase that touches PGP decryption. Read `~/Projects/proton-bridge/internal/services/imapservice/connector.go` function `GetMessageLiteral` (around line 216) for how Bridge fetches and decrypts a message. The pattern uses `gopenpgp` (which is already a dependency of `go-proton-api`).
+
+The redesigned `fetch_message` returns only the body (text/html), not the envelope fields. The envelope is already in the summary that the agent has from `list_mailbox` or `fetch_summaries`. Avoid re-duplication.
+
+### Tasks
+
+- [ ] Add types:
+  ```go
+  type EmailBody struct {
+      ID          EmailID `json:"id"`
+      ContentType string  `json:"contentType"` // "text/plain" or "text/html"
+      Body        string  `json:"body"`
+  }
+
+  type AttachmentContent struct {
+      EmailID     EmailID `json:"emailId"`
+      PartID      string  `json:"partId"`
+      Filename    string  `json:"filename"`
+      ContentType string  `json:"contentType"`
+      Data        string  `json:"data"` // base64
+      Size        int     `json:"size"`
+  }
+  ```
+- [ ] Implement `internal/mcp/tools/fetch_message.go`:
+  - Input: `{ id: string }`
+  - Call `client.GetFullMessage(ctx, id)` — returns the encrypted message
+  - Use the user's keyring (from session.KeyPass) to decrypt the body via gopenpgp
+  - Return `SingleToolResult[EmailBody]` — body content only
+- [ ] Implement `internal/mcp/tools/fetch_attachment.go`:
+  - Input: `{ emailId: string, partId: string }`
+  - Call `client.GetAttachment(ctx, partId)` — returns encrypted attachment
+  - Decrypt via gopenpgp using the appropriate key
+  - Return `SingleToolResult[AttachmentContent]` with base64-encoded data
+- [ ] Implement `internal/mcp/tools/search_mailbox.go`:
+  - Input: `{ mailbox: string, query: string, limit: int, offset: int }`
+  - Call `client.GetMessageMetadataPage()` with `Keyword` parameter
+  - Return `ListToolResult[EmailSummary]` (same shape as `list_mailbox`, includes attachment metadata)
+- [ ] Set up keyring management in `internal/proton/keys.go`:
+  - On `serve` startup, after refreshing the token, load and decrypt the user's primary key using `session.KeyPass`
+  - Store the keyring on the `ProtonClient` wrapper for use by decrypt operations
+  - Refresh keyring on token refresh
+
+### Tests
+
+- [ ] Add fake-server scenarios:
+  - Fetch a message body, assert it's decrypted plaintext/HTML (the fake server should provide test messages)
+  - Fetch an attachment, assert base64 length matches expected size
+  - Search for a keyword that exists in test data, assert at least one result with attachment metadata
+
+### Documentation
+
+- [ ] Tool entries in `docs/tools/README.md`
+- [ ] CHANGELOG entry — note `fetch_message` returns body only (TS issue #58 fixed by design)
+
+### Verification
+
+- [ ] Fetch a real message body via Inspector against a real account
+- [ ] Download a real attachment, verify it opens correctly
+- [ ] Search returns expected results
+- [ ] Fake-server smoke test passes
+- [ ] Tag `v0.6.0` and release
+
+### Commit
+
+```
+feat: add fetch_message, fetch_attachment, search_mailbox
+
+PGP decryption via gopenpgp using the stored salted key password.
+fetch_message returns body only — no envelope re-duplication
+(fixes TS issue #58 by design).
+
+Tag v0.6.0
+```
+
+---
+
+## Phase 9: Cutover
+
+**Goal:** Migrate users from `proton-bridge-mcp` to `proton-mail-mcp`. No release.
+
+### Tasks
+
+- [ ] Open a PR against `~/Projects/proton-bridge-mcp` updating the README:
+  - Add a deprecation banner at the top: "This project is in maintenance mode. The actively developed Go version is at https://github.com/grover/proton-mail-mcp"
+  - Add a "Migration Guide" section linking to a new doc
+- [ ] Create `docs/migration-from-typescript.md` in the new repo:
+  - For users coming from `proton-bridge-mcp`
+  - How to install the new MCPB
+  - How to migrate Claude Desktop configuration (the tool names are the same, so most existing usage should just work)
+  - Notes on the two tool changes: `verify_connectivity` -> `verify_session`, `drain_connections` removed
+  - Notes on the response shape changes: `fetch_message` body-only, `add_labels` no path
+- [ ] Update the new repo's README to link the migration guide
+- [ ] Add a section to the old repo's CHANGELOG noting the deprecation
+- [ ] Old repo enters maintenance mode: only security fixes
+- [ ] Set milestone in the old repo to track final maintenance work
+
+This phase produces no release. Cutover is a meta step.
+
+### Verification
+
+- [ ] Old repo README clearly directs users to the new one
+- [ ] Migration guide exists and is accurate
+- [ ] No silent breakage: users following the guide can install the new MCPB and continue with their existing Claude Desktop setup
+
+---
+
+## Phase 10: Cross-cutting Improvements
+
+**Goal:** Operational quality improvements after users have migrated. Release v0.7.0.
+
+### Tasks
+
+- [ ] **Audit log rotation** — port the design from TS issue #40. Use `gopkg.in/natefinch/lumberjack.v2` or implement simple size-based rotation in `internal/audit/`
+- [ ] **Better error mapping** — define structured error codes for the MCP responses:
+  - `AUTH_EXPIRED` — session needs re-login
+  - `RATE_LIMITED` — Proton API returned 429
+  - `LABEL_NOT_FOUND` — label name doesn't exist
+  - `EMAIL_NOT_FOUND` — message ID doesn't exist
+  - `INVALID_INPUT` — schema validation failure
+  - `INTERNAL` — anything else
+  - Return these codes in the MCP error responses so agents can react
+- [ ] **Rate limit refinements** — basic retry shipped in Phase 2, this phase adds:
+  - Configurable retry budget per call
+  - Metrics for rate-limit hits (logged via slog)
+  - Backoff jitter
+- [ ] **Telemetry / structured event logging** — use `log/slog` consistently across the codebase, ensure every tool call logs a structured event for production debugging
+- [ ] **Troubleshooting documentation** — create `docs/troubleshooting.md`:
+  - "Authentication errors" — what to do when refresh fails
+  - "Rate limit errors" — what they mean, how to back off
+  - "CAPTCHA / human verification" — how to recover (wait, change network, re-login)
+  - "Session expired mid-conversation" — instructing users to re-run `login`
+
+### Verification
+
+- [ ] Audit log rotates at the configured size
+- [ ] All error responses include structured error codes
+- [ ] Troubleshooting doc covers common failure modes
+- [ ] Tag `v0.7.0` and release
+
+### Commit
+
+```
+feat: cross-cutting improvements (audit log rotation, error codes, telemetry)
+
+Audit log size-based rotation. Structured MCP error codes for
+AUTH_EXPIRED, RATE_LIMITED, LABEL_NOT_FOUND, etc. Slog-based
+structured event logging for production debugging. Troubleshooting
+guide.
+
+Tag v0.7.0
+```
+
+---
+
+## Phase 11: HTTP/HTTPS Transports (Last)
+
+**Goal:** Add HTTP and HTTPS transports for non-STDIO use cases. Release v1.0.0 — feature parity with the TypeScript version.
+
+### Background
+
+Read `~/Projects/proton-bridge-mcp/src/http.ts` for the per-session model the TypeScript version uses. The Go MCP SDK should provide HTTP transport primitives — check its docs.
+
+### Tasks
+
+- [ ] Add `--http` flag to `serve`:
+  - Starts an HTTP server on a configurable port
+  - Bearer token auth via the `Authorization` header
+  - Per-session MCP server instances (one `mcp.Server` per HTTP session, keyed by session ID)
+- [ ] Add `--https` flag:
+  - Same as `--http` but with TLS
+  - Auto-generates a self-signed certificate if `--cert` and `--key` are not provided
+  - Use `crypto/tls` and `crypto/x509` from stdlib
+- [ ] Configuration via flags or env vars:
+  - `--port` / `PROTONMAIL_MCP_PORT`
+  - `--mcp-auth-token` / `PROTONMAIL_MCP_AUTH_TOKEN`
+  - `--cert`, `--key` (HTTPS)
+- [ ] Update the manifest.json to support HTTP mode if needed
+- [ ] Add fake-server smoke test scenarios for HTTP mode (Mode A only — Mode B can stay STDIO)
+- [ ] Document the configuration in `docs/configuration.md`
+
+### Verification
+
+- [ ] `proton-mail-mcp serve --http --port 6283 --mcp-auth-token secret` starts HTTP server
+- [ ] MCP Inspector connects via HTTP with the Bearer header
+- [ ] Requests without the token return 401
+- [ ] HTTPS variant works with auto-generated cert
+- [ ] Multiple concurrent sessions work without cross-contamination
+- [ ] Tag `v1.0.0` and release
+
+### Commit and release
+
+```
+feat: add HTTP/HTTPS transports — v1.0.0 feature parity
+
+proton-mail-mcp serve --http and --https with bearer token auth and
+per-session MCP server instances. Auto-generates self-signed cert
+for HTTPS if not provided.
+
+This release marks feature parity with proton-bridge-mcp.
+
+Tag v1.0.0
+```
+
+---
+
+## Documentation Maintenance
+
+Documentation is **not** a separate phase. Each phase that adds or changes a tool must, in the same commit series:
+
+- Add or update entries in `docs/tools/README.md`
+- Add an entry to `CHANGELOG.md` under `[Unreleased]`, then promote to a versioned section on release
+- Update `README.md` quickstart if relevant
+- Update `ARCHITECTURE.md` if the structure changes
+
+Don't defer documentation. It's part of the work.
+
+## Release Cadence Summary
+
+| Phase | Release | Tools / focus |
+|---|---|---|
+| 2 | v0.1.0 | `verify_session` + skeleton + MCPB + goreleaser + rate limit handling |
+| 4 | v0.2.0 | + `get_folders`, `get_labels`, `list_mailbox`, `fetch_summaries` (with attachment metadata) |
+| 5 | v0.3.0 | + `mark_read`, `mark_unread`, `revert_operations` (operation log online) |
+| 6 | v0.4.0 | + `create_folder`, `create_label`, `delete_folder`, `delete_label` |
+| 7 | v0.5.0 | + `move_emails`, `add_labels`, `remove_labels` |
+| 8 | v0.6.0 | + `fetch_message` (body only), `fetch_attachment`, `search_mailbox` |
+| 10 | v0.7.0 | Audit log rotation, error mapping, telemetry |
+| 11 | v1.0.0 | + HTTP/HTTPS transports — feature parity |
+
+Phase 3 (smoke test infrastructure) and Phase 9 (cutover) produce no release.
+
+## A short Go primer
+
+This appendix is for the user reading along, not for Claude. Claude should already know Go. If you're the user and you're new to Go, here are the absolute minimum concepts to recognize what's in this roadmap:
+
+**Packages**: A directory of `.go` files. Imported by path: `import "github.com/grover/proton-mail-mcp/internal/auth"`. Function visibility is by capitalization: `Login` is exported (public), `login` is package-private.
+
+**Methods on structs**: Go has no classes. A "method" is a function whose first parameter is the receiver, written as `func (s *Session) Refresh() error`. The `*` means pointer (mutable reference), like `Session&` in C++.
+
+**Interfaces**: A list of method signatures. Any type that implements those methods automatically satisfies the interface — no `implements` keyword needed. Go's "duck typing" with compile-time checks.
+
+**Errors**: Returned as the last value alongside a result. Always check `if err != nil { return err }`. Wrapping: `fmt.Errorf("context: %w", err)`.
+
+**Context**: `context.Context` is passed as the first parameter to every function that does I/O. It carries cancellation signals and deadlines. Always pass it through.
+
+**Goroutines and channels**: Go's concurrency primitives. You probably won't need them much in this roadmap — most of the work is sequential request/response.
+
+**Generics**: Added in Go 1.18. Used for the tool result types: `SingleToolResult[T any]`. The syntax is similar to TypeScript generics.
+
+**`go run` vs `go build`**: `go run ./cmd/X` compiles and runs in one step (slower, good for dev). `go build ./...` produces a binary you can ship.
+
+**The standard library is huge**: `net/http`, `encoding/json`, `crypto/aes`, `os`, `time`, `log/slog`, `context`, `sync` — almost everything you need is in the stdlib. Be skeptical of adding dependencies.
+
+**Read Bridge**: When you're stuck on a Go pattern, look at how `~/Projects/proton-bridge` does it. It's a 70k-line production Go codebase using the same library. You will rarely have to invent a pattern from scratch.
+
 # Go Migration Roadmap for `proton-mcp`
 
 > This document is a roadmap for migrating the proton-bridge-mcp TypeScript project to a new Go project called `proton-mcp`. It is **written for Claude as the executor** in the new repo. Read it cold, follow the phases in order, verify each phase before moving to the next.

--- a/docs/proton/authentication-flows.md
+++ b/docs/proton/authentication-flows.md
@@ -1,0 +1,510 @@
+# ProtonMail Authentication Flows — WebClients vs Bridge
+
+> Comparative analysis of authentication in [proton-mail/WebClients](https://github.com/ProtonMail/WebClients) and [proton-mail/proton-bridge](https://github.com/ProtonMail/proton-bridge), with assessment of how each could be adapted for an MCP server.
+
+## Overview
+
+Both the web client and Bridge authenticate to the same Proton API using the same SRP-6a protocol. The differences are in what happens *after* authentication: how sessions are stored, how keys are managed, and what authentication the downstream client (browser / IMAP client) uses.
+
+```
+Web Client:                          Bridge:                           MCP Server (proposed):
+Browser → SRP → Proton API           GUI → SRP → Proton API            CLI → SRP → Proton API
+  ↓                                    ↓                                  ↓
+  Cookie + localStorage               Encrypted vault file               ???
+  ↓                                    ↓                                  ↓
+  API calls with UID header            API calls with UID header          API calls with UID header
+                                       ↓
+                                       Generate BridgePass (random)
+                                       ↓
+                                       IMAP client → BridgePass → Bridge
+```
+
+## SRP-6a — The Shared Foundation
+
+Both implementations use SRP-6a (Secure Remote Password), a zero-knowledge proof protocol where the server never sees the user's password. The protocol has 5 auth versions (0-4) for backward compatibility.
+
+### The Handshake
+
+```
+Client                                    Server
+  │                                         │
+  │──── GET /core/v4/auth/info ────────────→│  "I'm user X"
+  │                                         │
+  │←── { Modulus, ServerEphemeral, ────────│  SRP challenge parameters
+  │      Version, Salt, SRPSession }        │
+  │                                         │
+  │  [hash password with salt + modulus]    │
+  │  [generate client proof]               │
+  │                                         │
+  │──── POST /core/v4/auth ────────────────→│  { ClientProof, ClientEphemeral, SRPSession }
+  │                                         │
+  │←── { ServerProof, UID, AccessToken, ───│  Mutual authentication
+  │      RefreshToken, 2FA, ... }           │
+  │                                         │
+  │  [verify ServerProof]                  │
+  │                                         │
+```
+
+### Web Client SRP Implementation
+
+**[packages/srp/lib/srp.ts:184-221](~/Projects/WebClients/packages/srp/lib/srp.ts)** (259 lines, MIT license):
+
+```typescript
+export const getSrp = async (
+    { Version, Modulus: serverModulus, ServerEphemeral, Username, Salt }: AuthInfo,
+    { username, password }: AuthCredentials,
+    authVersion = Version
+) => {
+    const modulusArray = await verifyAndGetModulus(serverModulus);
+    const serverEphemeralArray = Uint8Array.fromBase64(ServerEphemeral);
+
+    const hashedPasswordArray = await hashPassword({
+        version: authVersion,
+        password,
+        salt: authVersion < 3 ? undefined : uint8ArrayToString(Uint8Array.fromBase64(Salt)),
+        username: authVersion < 3 ? Username : undefined,
+        modulus: modulusArray,
+    });
+
+    const { clientEphemeral, clientProof, expectedServerProof } = await generateProofs({
+        byteLength: SRP_LEN,
+        modulusArray,
+        hashedPasswordArray,
+        serverEphemeralArray,
+    });
+
+    return {
+        clientEphemeral: clientEphemeral.toBase64(),
+        clientProof: clientProof.toBase64(),
+        expectedServerProof: expectedServerProof.toBase64(),
+    };
+};
+```
+
+**Password hashing varies by auth version** ([packages/srp/lib/passwords.ts:63-102](~/Projects/WebClients/packages/srp/lib/passwords.ts)):
+- **Version 0-2**: Hash with username (legacy, no salt)
+- **Version 3**: bcrypt with salt, then hash with modulus
+- **Version 4**: Same as 3 (current)
+
+The version fallback logic ([packages/srp/lib/getAuthVersionWithFallback.ts](~/Projects/WebClients/packages/srp/lib/getAuthVersionWithFallback.ts)) tries the server-reported version first, then falls back to older versions if "wrong password" is returned. This handles accounts that haven't been migrated to newer auth versions.
+
+### Bridge SRP Implementation
+
+Bridge delegates SRP entirely to `go-proton-api`:
+
+**[go.mod:10](~/Projects/proton-bridge/go.mod):**
+```
+github.com/ProtonMail/go-proton-api v0.4.1-0.20260319112440-799673ddc2db
+```
+
+Transitive dependency: `github.com/ProtonMail/go-srp v0.0.7`
+
+**[internal/bridge/user.go:134](~/Projects/proton-bridge/internal/bridge/user.go):**
+```go
+client, auth, err := bridge.api.NewClientWithLoginWithHVToken(ctx, username, password, hvDetails)
+```
+
+Bridge never touches SRP internals. One function call handles the full handshake.
+
+## Two-Factor Authentication
+
+### AuthResponse — What Comes Back
+
+**[packages/shared/lib/authentication/interface.ts:16-30](~/Projects/WebClients/packages/shared/lib/authentication/interface.ts):**
+```typescript
+export interface AuthResponse {
+    AccessToken: string;
+    ExpiresIn: number;
+    TokenType: string;
+    Scope: string;
+    UID: string;
+    UserID: string;
+    RefreshToken: string;
+    EventID: string;
+    TemporaryPassword: 0 | 1;
+    PasswordMode: number;    // 1 = single password, 2 = two-password mode
+    LocalID: number;
+    TwoFactor: number;       // Bitmask: 0 = none, 1 = TOTP, 2 = FIDO2
+    '2FA': TwoFaResponse;
+}
+```
+
+### Web Client 2FA
+
+After the initial auth response, the web client checks `TwoFactor`:
+- **TOTP**: Shows input field, calls `POST /core/v4/auth/2fa` with `{ TwoFactorCode }`
+- **FIDO2**: Shows WebAuthn challenge, calls same endpoint with `{ FIDO2: credential }`
+
+### Bridge 2FA
+
+**[internal/bridge/user.go:209-220](~/Projects/proton-bridge/internal/bridge/user.go):**
+```go
+if auth.TwoFA.Enabled&proton.HasTOTP != 0 {
+    totp, err := getTOTP()   // Callback — Bridge GUI prompts user
+    if err != nil {
+        return "", fmt.Errorf("failed to get TOTP: %w", err)
+    }
+
+    if err := client.Auth2FA(ctx, proton.Auth2FAReq{TwoFactorCode: totp}); err != nil {
+        return "", fmt.Errorf("failed to authorize 2FA: %w", err)
+    }
+}
+```
+
+Bridge only supports TOTP, not FIDO2. The TOTP code is obtained via a callback function that the GUI provides.
+
+## Two-Password Mode
+
+ProtonMail supports an optional "two-password mode" where the login password and the mailbox decryption password are different.
+
+### Bridge Handling
+
+**[internal/bridge/user.go:222-235](~/Projects/proton-bridge/internal/bridge/user.go):**
+```go
+if auth.PasswordMode == proton.TwoPasswordMode {
+    userKeyPass, err := getKeyPass()  // Callback — GUI prompts for mailbox password
+    keyPass = userKeyPass
+} else {
+    keyPass = password  // Single password mode: login password IS the key password
+}
+```
+
+In single-password mode (the default for most users), the login password doubles as the key password for decrypting private keys.
+
+### Web Client Handling
+
+The web client handles this in `loginActions.ts` — if `PasswordMode === 2`, it prompts for a second password before proceeding to key decryption.
+
+## Post-Auth: Key Decryption
+
+After authentication, both implementations must decrypt the user's private PGP keys to read email.
+
+### Web Client Key Setup
+
+1. `GET core/v4/users` — fetch user info including encrypted key list
+2. `GET core/v4/keys/salts` — fetch per-key salts
+3. Compute `keyPassword = bcrypt(loginPassword, keySalt)`
+4. `CryptoProxy.importPrivateKey(armoredKey, keyPassword)` — decrypt private key
+5. Store `keyPassword` in encrypted session blob (localStorage)
+
+### Bridge Key Setup
+
+**[internal/bridge/user.go:372-399](~/Projects/proton-bridge/internal/bridge/user.go):**
+```go
+func (bridge *Bridge) loginUser(ctx context.Context, client *proton.Client, 
+    authUID, authRef string, keyPass []byte, hvDetails *proton.APIHVDetails) (string, error) {
+    apiUser, err := client.GetUserWithHV(ctx, hvDetails)
+    salts, err := client.GetSalts(ctx)
+    saltedKeyPass, err := salts.SaltForKey(keyPass, apiUser.Keys.Primary().ID)
+    userKR, err := apiUser.Keys.Unlock(saltedKeyPass, nil)
+    // ... store auth + keyPass in vault
+}
+```
+
+The `saltedKeyPass` is stored in the vault for future use. On restart, Bridge doesn't need the original password — it loads `keyPass` from the vault and unlocks keys directly.
+
+## Session Persistence — The Critical Difference
+
+### Web Client: Browser Storage
+
+**[packages/shared/lib/authentication/persistedSessionStorage.ts](~/Projects/WebClients/packages/shared/lib/authentication/persistedSessionStorage.ts):**
+
+Sessions are stored in `localStorage` with prefix `ps-{localID}`:
+```typescript
+interface PersistedSession {
+    localID: number;
+    UserID: string;
+    UID: string;
+    AccessToken: string;
+    RefreshToken: string;
+    blob: string;       // AES-encrypted keyPassword
+    persistent: boolean;
+    trusted: boolean;
+}
+```
+
+The `keyPassword` is encrypted with a `ClientKey` that is stored server-side (`POST /auth/v4/sessions/local/key`). On page reload, the client fetches the ClientKey, decrypts the blob, and resumes.
+
+### Bridge: Encrypted Vault File
+
+**[internal/vault/types_user.go:24-45](~/Projects/proton-bridge/internal/vault/types_user.go):**
+```go
+type UserData struct {
+    UserID       string
+    Username     string
+    PrimaryEmail string
+
+    AuthUID string      // API session UID
+    AuthRef string      // Refresh token
+    KeyPass []byte      // Salted mailbox password (for key decryption)
+
+    BridgePass  []byte  // Random 16-byte token for IMAP/SMTP auth
+    AddressMode AddressMode
+    SyncStatus  SyncStatus
+    EventID     string
+}
+```
+
+Stored in `vault.enc`, encrypted with AES-256-GCM. The vault encryption key is derived internally (not stored in OS keychain in this version).
+
+### Key Difference
+
+| | Web Client | Bridge |
+|---|---|---|
+| **Storage** | Browser localStorage | Encrypted file on disk |
+| **keyPassword protection** | Server-side ClientKey + AES | Vault AES-256-GCM |
+| **Survives restart** | Yes (with cookie/localStorage) | Yes (vault file) |
+| **Refresh token** | In persisted session blob | In vault UserData |
+| **Multi-account** | Multiple `ps-{localID}` entries | Multiple UserData in vault |
+
+## Token Refresh
+
+### Web Client
+
+**[packages/shared/lib/api/helpers/refreshHandlers.ts](~/Projects/WebClients/packages/shared/lib/api/helpers/refreshHandlers.ts):**
+
+On 401 response:
+1. Mutex-protected refresh (prevents cross-tab races)
+2. `POST /auth/refresh` with RefreshToken (via cookie)
+3. New AccessToken + RefreshToken returned
+4. Retry original request
+5. If refresh fails with 4xx, emit `ApiLogoutEvent` — session is dead
+
+### Bridge
+
+**[internal/bridge/user.go:445-478](~/Projects/proton-bridge/internal/bridge/user.go):**
+```go
+func (bridge *Bridge) loadUser(ctx context.Context, user *vault.User) error {
+    client, auth, err := bridge.api.NewClientWithRefresh(ctx, user.AuthUID(), user.AuthRef())
+    if err != nil {
+        if apiErr.Code == proton.AuthRefreshTokenInvalid {
+            if err := user.Clear(); err != nil { /* clear auth */ }
+        }
+        return err
+    }
+
+    if err := user.SetAuth(auth.UID, auth.RefreshToken); err != nil {
+        return err
+    }
+    // ... continue with user setup
+}
+```
+
+On startup, Bridge refreshes all stored sessions. If a refresh token is invalid, the user is logged out and must re-authenticate.
+
+## Bridge Password — The IMAP Authentication Layer
+
+This is unique to Bridge and has no equivalent in the web client.
+
+**[internal/vault/vault.go:220-223](~/Projects/proton-bridge/internal/vault/vault.go):**
+```go
+bridgePass := data.Settings.PasswordArchive.get(primaryEmail)
+if len(bridgePass) == 0 {
+    bridgePass = newRandomToken(16)
+}
+```
+
+A random 16-byte token is generated per user, stored in the vault, and base64-encoded for display. IMAP/SMTP clients authenticate with `email + base64(bridgePass)`.
+
+**[internal/services/useridentity/state.go:229-254](~/Projects/proton-bridge/internal/services/useridentity/state.go):**
+```go
+func (s *State) CheckAuth(email string, password []byte, 
+    bridgePassProvider BridgePassProvider) (string, error) {
+    dec, err := algo.B64RawDecode(password)
+    if err != nil {
+        return "", fmt.Errorf("failed to decode password: %w", err)
+    }
+
+    if subtle.ConstantTimeCompare(bridgePassProvider.BridgePass(), dec) != 1 {
+        return "", fmt.Errorf("invalid password")
+    }
+    // ... match email to address
+}
+```
+
+The constant-time comparison (`subtle.ConstantTimeCompare`) prevents timing attacks on the bridge password.
+
+## Human Verification / CAPTCHA
+
+Both implementations handle Proton's anti-abuse challenges:
+
+### Web Client
+API returns error code `HUMAN_VERIFICATION_REQUIRED` with available methods (captcha, email, SMS). The listener shows a verification UI. On completion, the original request is retried with `X-PM-Human-Verification-Token` header.
+
+### Bridge
+**[internal/bridge/user.go:136-140](~/Projects/proton-bridge/internal/bridge/user.go):**
+```go
+if hv.IsHvRequest(err) {
+    return nil, proton.Auth{}, err  // Propagates HV request to caller
+}
+```
+
+Bridge passes the HV challenge to its GUI. The GUI presents a WebView with the CAPTCHA, collects the token, and retries login with `hvDetails`.
+
+## Session Forking — Web Client Only
+
+**[packages/shared/lib/authentication/fork/](~/Projects/WebClients/packages/shared/lib/authentication/fork/)**
+
+The web client has an elaborate session forking mechanism for SSO across Proton apps (mail, calendar, drive, etc.):
+
+1. **Parent app** generates a random 32-byte AES key
+2. Encrypts `keyPassword` with the AES key
+3. Calls `POST /auth/v4/sessions/forks` with encrypted payload -> gets `selector`
+4. Constructs URL: `https://child-app/#selector=X&sk=<base64-key>&v=2`
+5. **Child app** extracts `selector` + `sk` from URL hash
+6. Calls `GET /auth/v4/sessions/forks/{selector}` -> gets encrypted payload + session tokens
+7. Decrypts `keyPassword` using `sk`
+8. Session is now active in child app
+
+This is purely a browser concern and irrelevant for an MCP server.
+
+## Adaptation for an MCP Server
+
+### Option A: Adapt the Bridge Approach
+
+**Use Bridge's authentication flow but store tokens yourself.**
+
+```
+MCP Server Startup:
+  1. Check for stored session (vault/config file)
+  2. If found: refresh token → API ready
+  3. If not: SRP login → store session → API ready
+
+Auth dependencies needed:
+  - @proton/srp (MIT, 700 lines) — SRP-6a handshake
+  - @proton/crypto (MIT) — for SRP's BigInt and hashing
+  - Token storage — encrypted file, OS keychain, or env vars
+```
+
+**Pros:**
+- Battle-tested flow (Bridge uses it in production)
+- No browser dependencies
+- Token refresh is straightforward
+- Can store keyPass for subsequent restarts
+
+**Cons:**
+- Must handle TOTP interactively (prompt user on first login)
+- Must handle HV/CAPTCHA (harder without a GUI)
+- Go's `go-proton-api` library wraps SRP beautifully; no TypeScript equivalent exists
+- Must implement key management (salt, decrypt private keys) for message reading
+
+### Option B: Adapt the Web Client Approach
+
+**Port the web client's auth flow to Node.js.**
+
+```
+MCP Server Startup:
+  1. configureApi({ API_URL, APP_VERSION, clientID, protonFetch: nodeFetch })
+  2. loginWithFallback({ api, credentials })
+  3. If 2FA: prompt for TOTP
+  4. persistSession locally (encrypted file instead of localStorage)
+  5. loadCryptoWorker → adapt for Node.js (no Web Workers)
+  6. API ready
+
+Auth dependencies needed:
+  - @proton/srp (MIT) — use directly
+  - @proton/crypto (MIT) — adapt CryptoProxy for Node.js
+  - @protontech/pmcrypto (npm) — OpenPGP operations
+  - Custom: configureApi reimplementation (trivial, 80 lines)
+  - Custom: session storage (replace localStorage with file)
+```
+
+**Pros:**
+- TypeScript-native (same language as MCP server)
+- SRP and crypto packages are MIT-licensed
+- API endpoint definitions are just `{ method, url, data }` objects — easy to replicate
+- Web client auth flow is more feature-complete (SSO, offline keys, scopes)
+
+**Cons:**
+- `@proton/crypto` uses Web Workers via `comlink` — needs Node.js adaptation
+- `@proton/shared` is GPL-3.0 — can't import directly; must clean-room the glue code
+- More moving parts than Bridge's single `NewClientWithLogin` call
+- CAPTCHA handling requires a browser or WebView
+
+### Option C: Hybrid — Use Bridge as Auth Proxy
+
+**Keep using Bridge for IMAP, but also authenticate directly for API operations that IMAP can't do.**
+
+```
+MCP Server:
+  1. Connect to Bridge IMAP (existing flow)
+  2. Also: read Bridge's vault file to extract AuthUID + AuthRef
+  3. Use extracted tokens to call Proton API directly
+  4. Use IMAP for reads, API for label operations
+
+Dependencies needed:
+  - vault.enc decryption (AES-256-GCM, need vault key)
+  - Token refresh logic
+  - No SRP needed (Bridge already authenticated)
+```
+
+**Pros:**
+- No SRP implementation needed
+- No password handling
+- Bridge handles CAPTCHA, 2FA, key management
+- Incremental — add API calls alongside IMAP gradually
+
+**Cons:**
+- Depends on Bridge's internal vault format (undocumented, may change)
+- Vault encryption key derivation must be reverse-engineered
+- Bridge and MCP server could race on token refresh
+- Fragile coupling to Bridge internals
+
+### Recommendation
+
+**Option A (Bridge approach) is the most viable for a standalone MCP server.** The flow is:
+
+1. **First run**: Prompt for username + password + TOTP
+2. SRP handshake via `@proton/srp` (MIT)
+3. Store `{ AuthUID, RefreshToken, KeyPass }` in encrypted config
+4. **Subsequent runs**: Refresh token, decrypt keys, ready
+5. API calls with `UID` header for all operations
+
+The main implementation effort is:
+- Port SRP glue code (~130 lines, clean-room from GPL `@proton/shared`)
+- Adapt `@proton/crypto` for Node.js (remove Web Worker dependency)
+- Build token storage and refresh
+- Handle TOTP prompt on first login
+- Handle CAPTCHA (hardest part — may need an embedded browser)
+
+The CAPTCHA problem is the real blocker. Both Bridge (GUI with WebView) and web client (browser-native) have visual interfaces for solving challenges. A headless MCP server would need either a temporary browser window or a way to present the challenge to the user.
+
+## Complete Auth Flow Comparison
+
+| Step | Web Client | Bridge | MCP Server (proposed) |
+|---|---|---|---|
+| **SRP handshake** | `@proton/srp` (TypeScript, MIT) | `go-proton-api` + `go-srp` (Go) | `@proton/srp` (reuse TypeScript) |
+| **2FA** | Browser UI | GUI callback | CLI prompt |
+| **CAPTCHA** | Browser-native | GUI WebView | Embedded browser? CLI URL? |
+| **Key decrypt** | `CryptoProxy` (Web Workers) | `go-crypto` (Go) | `CryptoProxy` (adapted for Node) |
+| **Session store** | localStorage + server ClientKey | Encrypted vault file | Encrypted config file |
+| **Token refresh** | Auto on 401, mutex-protected | On startup, stored in vault | On startup + auto on 401 |
+| **Downstream auth** | Cookie + UID header | BridgePass (random token) | UID header (direct API) |
+| **Password mode** | Prompt for 2nd password | GUI callback | CLI prompt |
+
+## Key Source Files
+
+### Web Client
+| File | Purpose |
+|---|---|
+| [packages/srp/lib/srp.ts](~/Projects/WebClients/packages/srp/lib/srp.ts) | Core SRP-6a (259 lines, MIT) |
+| [packages/srp/lib/passwords.ts](~/Projects/WebClients/packages/srp/lib/passwords.ts) | Password hashing per version (102 lines) |
+| [packages/shared/lib/authentication/loginWithFallback.ts](~/Projects/WebClients/packages/shared/lib/authentication/loginWithFallback.ts) | Login orchestration (68 lines, GPL) |
+| [packages/shared/lib/srp.ts](~/Projects/WebClients/packages/shared/lib/srp.ts) | SRP auth glue (130 lines, GPL) |
+| [packages/shared/lib/authentication/interface.ts](~/Projects/WebClients/packages/shared/lib/authentication/interface.ts) | Auth types: AuthResponse, InfoResponse (110 lines) |
+| [packages/shared/lib/api/auth.ts](~/Projects/WebClients/packages/shared/lib/api/auth.ts) | Auth API endpoints (220 lines, GPL) |
+| [packages/shared/lib/api.ts](~/Projects/WebClients/packages/shared/lib/api.ts) | configureApi (80 lines, GPL) |
+| [packages/shared/lib/api/helpers/refreshHandlers.ts](~/Projects/WebClients/packages/shared/lib/api/helpers/refreshHandlers.ts) | Token refresh (101 lines) |
+| [packages/shared/lib/authentication/persistedSessionHelper.ts](~/Projects/WebClients/packages/shared/lib/authentication/persistedSessionHelper.ts) | Session persist/resume |
+| [packages/shared/lib/authentication/fork/](~/Projects/WebClients/packages/shared/lib/authentication/fork/) | SSO session forking |
+
+### Bridge
+| File | Purpose |
+|---|---|
+| [internal/bridge/user.go](~/Projects/proton-bridge/internal/bridge/user.go) | LoginAuth, LoginUser, LoginFull, loadUser (478 lines) |
+| [internal/vault/types_user.go](~/Projects/proton-bridge/internal/vault/types_user.go) | UserData struct with auth fields (97 lines) |
+| [internal/vault/vault.go](~/Projects/proton-bridge/internal/vault/vault.go) | Vault encryption, bridge password generation |
+| [internal/services/useridentity/state.go](~/Projects/proton-bridge/internal/services/useridentity/state.go) | CheckAuth, WithAddrKR (key ring access) |
+| [internal/services/imapservice/connector.go](~/Projects/proton-bridge/internal/services/imapservice/connector.go) | IMAP Authorize (bridge password check) |
+| [internal/services/smtp/smtp_backend.go](~/Projects/proton-bridge/internal/services/smtp/smtp_backend.go) | SMTP AuthPlain |
+| [pkg/keychain/keychain.go](~/Projects/proton-bridge/pkg/keychain/keychain.go) | OS keychain abstraction |

--- a/docs/proton/authentication-flows.md
+++ b/docs/proton/authentication-flows.md
@@ -655,6 +655,164 @@ If the refresh token is revoked while the agent is mid-conversation (Proton acco
 
 This is preferable to attempting interactive re-authentication mid-conversation — the agent environment may not support elicitation, the TOTP code has a short window, and mixing authentication prompts into an email management conversation is confusing.
 
+## Porting Evaluation: go-proton-api to TypeScript vs MCP Server to Go
+
+Two migration paths exist. Both eliminate the IMAP middleman. The question is which language the MCP server should live in.
+
+### Path 1: Port go-proton-api to TypeScript
+
+**What it is:** Translate Proton's Go API client library into TypeScript so the existing TypeScript MCP server can call the Proton REST API directly instead of going through Bridge IMAP.
+
+**Scope of go-proton-api:**
+
+The Bridge uses ~19 distinct API methods on `proton.Client` and references 154+ types/constants from the proton package. The library handles:
+
+- SRP authentication (delegates to `go-srp`)
+- Session management (token refresh, auth handlers)
+- PGP encryption/decryption (delegates to `gopenpgp`)
+- REST API calls (messages, labels, conversations, attachments, settings, events)
+- Error handling (API error codes, human verification)
+
+**Dependency chain (all GPL):**
+```
+go-proton-api (GPL)
+├── go-srp v0.0.7 (GPL)
+├── gopenpgp v2.9.0-proton (GPL)
+│   └── go-crypto v1.3.0-proton (GPL)
+└── stdlib (net/http, crypto, etc.)
+```
+
+**Assessment:**
+
+| Factor | Rating | Notes |
+|---|---|---|
+| **Size** | Large | 19+ API methods, 154+ types, plus SRP + crypto. Not a weekend project. |
+| **Crypto porting** | Hard | `gopenpgp` wraps Go's `crypto/openpgp` fork with Proton-specific patches. TypeScript equivalent exists (`@protontech/pmcrypto` + `@protontech/openpgp`) but the API surfaces differ significantly. |
+| **SRP porting** | Unnecessary | `@proton/srp` (TypeScript, MIT) already exists and is production-quality. No need to port `go-srp`. |
+| **License** | Blocker | go-proton-api is GPL. A port is a derivative work — the TypeScript version would also be GPL. This contaminates the MCP server if linked. |
+| **API surface match** | Poor | go-proton-api is designed for Go idioms (context.Context, io.Reader streams, goroutine-safe methods). A direct port would feel alien in TypeScript. A clean-room TypeScript client using the WebClients API definitions (which are just `{ method, url, data }` objects) would be more natural. |
+| **Maintenance** | Unsustainable | Proton updates go-proton-api for Bridge releases. A forked TypeScript port would drift immediately. No automated way to keep in sync. |
+| **Claude feasibility** | Medium | Claude can translate Go to TypeScript mechanically, but the crypto integration requires deep understanding of OpenPGP key handling, armored message formats, and Proton's proprietary extensions. Automated translation would produce compiling code that fails on edge cases. |
+
+**Verdict: Don't port go-proton-api.** Instead, build a TypeScript API client from scratch using the WebClients endpoint definitions (MIT for `@proton/srp` and `@proton/crypto`, clean-room for the GPL glue). See [webclient-api-extraction.md](webclient-api-extraction.md) for that analysis.
+
+### Path 2: Migrate the MCP Server from TypeScript to Go
+
+**What it is:** Rewrite the MCP server in Go, replacing the IMAP layer with direct `go-proton-api` calls. The server becomes architecturally similar to Bridge itself — a Go process that authenticates to the Proton API, manages keys, and exposes MCP tools.
+
+**Current TypeScript codebase:**
+
+| Component | Lines | Go equivalent |
+|---|---|---|
+| Production code | 2,903 | ~3,500-4,000 (Go is more verbose) |
+| Test code | 2,580 | ~3,000 |
+| IMAP client (`imap.ts`) | 655 | **Eliminated entirely** — replaced by `proton.Client` method calls |
+| Connection pool (`pool.ts`) | 312 | **Eliminated** — go-proton-api manages its own HTTP client |
+| Operation log + interceptor | 364 | ~400 (similar logic, no decorators) |
+| Tool handlers (18 tools) | ~300 | ~350 |
+| Server setup + transports | ~470 | ~500 (Go MCP SDK + net/http) |
+| Types | 380 | **Mostly eliminated** — use `proton` package types directly |
+| Config + logging | 186 | ~200 |
+
+**What gets eliminated by switching from IMAP to go-proton-api:**
+
+| Current IMAP complexity | Replaced by |
+|---|---|
+| `ImapClient` (655 lines of IMAP protocol) | Direct `proton.Client.LabelMessages()`, `GetMessage()`, etc. |
+| Connection pool (312 lines) | go-proton-api's internal HTTP client |
+| `isAlreadyExistsError` + LIST fallback | API returns structured errors with codes |
+| COPYUID parsing for label copies | Not needed — API works with MessageIDs, not UIDs |
+| Message-ID search for `remove_labels` | `proton.Client.UnlabelMessages(messageIDs, labelID)` — one call |
+| UID rewriting chain in revert | Not needed — MessageIDs are stable across label changes |
+| `Labels/` path devirtualization | Not needed — labels are native label IDs |
+| `mailparser` for MIME parsing | `proton.Client.GetFullMessage()` returns structured data |
+| `imapflow` dependency | Eliminated |
+
+**What gets added:**
+
+| New responsibility | Complexity |
+|---|---|
+| SRP authentication | Handled by go-proton-api — zero code |
+| Token storage + refresh | ~100 lines (encrypted vault, similar to Bridge) |
+| PGP decryption of message bodies | `gopenpgp` library — but Bridge already does this, patterns exist |
+| Key management (salt, decrypt private keys) | ~50 lines (copy Bridge's pattern from `user.go`) |
+| TOTP + CAPTCHA handling | ~150 lines (CLI prompt + browser spawn, as discussed above) |
+| Event polling for real-time sync (optional) | ~200 lines if needed, skip for v1 |
+
+**Go MCP SDK:** An official Go SDK exists at `github.com/modelcontextprotocol/go-sdk` (maintained with Google). It supports stdio, SSE, and HTTP transports.
+
+**Go library equivalents:**
+
+| TypeScript dependency | Go equivalent |
+|---|---|
+| `@modelcontextprotocol/sdk` | `github.com/modelcontextprotocol/go-sdk` |
+| `imapflow` | **Eliminated** — direct API |
+| `mailparser` | **Eliminated** — structured API responses |
+| `fastify` | `net/http` (stdlib) |
+| `pino` | `github.com/sirupsen/logrus` or `log/slog` (stdlib) |
+| `commander` | `github.com/spf13/cobra` |
+| `zod` | `go-playground/validator` or manual |
+| `selfsigned` | `crypto/x509` (stdlib) |
+
+**Assessment:**
+
+| Factor | Rating | Notes |
+|---|---|---|
+| **Net code reduction** | Significant | ~1,000 lines of IMAP plumbing eliminated. Types reused from go-proton-api. Total Go codebase would be ~2,000-2,500 lines (smaller than current TypeScript). |
+| **Architectural simplification** | Major | No IMAP virtualization/devirtualization. Labels are labels. UIDs are MessageIDs. No COPYUID. No Message-ID search. The entire [label-handling.md](../impl/label-handling.md) design doc becomes irrelevant. |
+| **Label operations** | Trivial | `add_labels` = `client.LabelMessages(ids, labelID)`. `remove_labels` = `client.UnlabelMessages(ids, labelID)`. No copy resolution, no two-phase lookup. |
+| **Authentication** | Free | go-proton-api handles SRP, token refresh, 2FA. Bridge's `LoginFull` is a 50-line function. |
+| **Crypto** | Comes with | `gopenpgp` is already a go-proton-api dependency. Key decryption follows Bridge's exact pattern. |
+| **License** | GPL (same as now) | go-proton-api is GPL, making the Go MCP server GPL too. But proton-bridge is already GPL, so this matches the ecosystem. If you want non-GPL, neither path works — you'd need the TypeScript clean-room approach. |
+| **Deployment** | Better | Single static binary. No Node.js runtime. No `node_modules`. Cross-compile for any OS. |
+| **Bridge dependency** | Eliminated | The MCP server becomes a standalone Proton client. Bridge is no longer needed at all. |
+| **Claude feasibility** | High | 2,903 lines of well-structured TypeScript with clear interfaces. Go has direct equivalents for every pattern except decorators (which become wrapper functions). The IMAP layer doesn't need translation — it's deleted. Claude would need ~3-5 sessions to port the core, with the main risk being the Go MCP SDK integration (newer library, less training data). |
+| **Test porting** | Medium | 2,580 lines of Jest tests. Go's `testing` package + `testify` assertions. The IMAP mock layer is eliminated; replaced by go-proton-api's built-in fake server (`go-proton-api/server.Server`), which is what Bridge uses for its own tests. |
+| **Development velocity** | Slower initially | Go's type system is simpler but more verbose. No union types, no generics on interfaces (limited generics). Error handling is explicit (`if err != nil`). Build-test cycle is fast though. |
+
+**What Bridge already solved that you'd reuse:**
+
+The Bridge codebase at `~/Projects/proton-bridge` is a reference implementation for everything the Go MCP server needs:
+
+| Concern | Bridge file to reference | Lines |
+|---|---|---|
+| Login + 2FA + key unlock | `internal/bridge/user.go` (LoginFull) | ~120 |
+| Token refresh | `internal/bridge/user.go` (loadUser) | ~35 |
+| Encrypted vault | `internal/vault/` | ~500 |
+| Label operations | `internal/services/imapservice/connector.go` | ~200 |
+| Message fetching | `internal/services/imapservice/connector.go` | ~100 |
+| Flag management | `internal/services/imapservice/connector.go` | ~30 |
+| Event polling | `internal/services/imapservice/service_message_events.go` | ~300 |
+
+You wouldn't copy Bridge code (different architecture), but the patterns for "how to use go-proton-api correctly" are all there.
+
+### Comparison: Both Paths
+
+| Dimension | Port go-proton-api to TS | Migrate MCP server to Go |
+|---|---|---|
+| **Eliminates IMAP** | Yes | Yes |
+| **Eliminates Bridge dependency** | Yes | Yes |
+| **License** | GPL (derivative of go-proton-api) or clean-room (hard) | GPL (uses go-proton-api directly) |
+| **Crypto** | Must adapt @proton/crypto for Node.js (Web Workers) | gopenpgp works natively in Go |
+| **Auth** | Must port SRP glue (~130 lines clean-room) | go-proton-api handles everything |
+| **Reference implementation** | WebClients (TypeScript, but GPL shared) | Bridge (Go, GPL, exact same library) |
+| **Net effort** | ~8-10 days (see [webclient-api-extraction.md](webclient-api-extraction.md)) | ~10-15 days (full rewrite but simpler architecture) |
+| **Maintenance burden** | High — custom TS API client must track Proton API changes | Low — go-proton-api is maintained by Proton |
+| **Risk** | Medium — crypto adaptation, no reference Go→TS port exists | Low — Bridge proves the patterns work |
+| **Claude assist quality** | Medium — crypto edge cases, Web Worker adaptation | High — straightforward Go, Bridge as reference |
+
+### Recommendation
+
+**If you're going to eliminate IMAP, migrate to Go.** The numbers are close on effort, but Go wins on every qualitative dimension:
+
+1. **go-proton-api is the canonical client** — maintained by Proton, used by Bridge in production. A TypeScript API client would be a second-class citizen maintained by you.
+2. **Crypto just works** — `gopenpgp` is native Go. No Web Worker adaptation, no `comlink`, no Node.js crypto quirks.
+3. **Bridge is the reference implementation** — every pattern you need exists in `~/Projects/proton-bridge`, in the same language, using the same library.
+4. **The IMAP layer disappears** — this isn't a 1:1 rewrite. ~1,000 lines of IMAP plumbing, the connection pool, UID mapping, label devirtualization, and COPYUID resolution all vanish. The Go version would be architecturally simpler than the TypeScript version.
+5. **Single binary deployment** — `go build` produces one executable. No Node.js, no `node_modules`, no `npm install`.
+
+The main cost is the language switch. If you're not comfortable in Go, the ramp-up time is real. But the TypeScript path has its own ramp-up: adapting `@proton/crypto` for Node.js, clean-rooming the GPL glue code, and building a custom API client that Proton doesn't maintain.
+
 ## Complete Auth Flow Comparison
 
 | Step | Web Client | Bridge | MCP Server (proposed) |

--- a/docs/proton/authentication-flows.md
+++ b/docs/proton/authentication-flows.md
@@ -469,6 +469,192 @@ The main implementation effort is:
 
 The CAPTCHA problem is the real blocker. Both Bridge (GUI with WebView) and web client (browser-native) have visual interfaces for solving challenges. A headless MCP server would need either a temporary browser window or a way to present the challenge to the user.
 
+## TOTP and CAPTCHA in an Agent-Coupled MCP Server
+
+An MCP server running behind an AI agent faces a unique challenge: interactive authentication steps (TOTP codes, CAPTCHAs) must be resolved without a traditional GUI, potentially during an ongoing agent conversation. The MCP protocol itself offers mechanisms for this, but the design tradeoffs are non-obvious.
+
+### When Do These Challenges Occur?
+
+Neither TOTP nor CAPTCHA is needed on every startup. Understanding the frequency matters for choosing a strategy:
+
+| Challenge | When triggered | Frequency |
+|---|---|---|
+| **TOTP** | Initial login only. Token refresh does not require 2FA. | Once — on first-ever authentication, or after session expiry/revocation. |
+| **CAPTCHA** | Proton's anti-abuse system flags the request. Triggered by: new IP, VPN, Tor, suspicious patterns, rate limiting. | Rare — may never occur for a stable home IP. Likely on first login from a new network. |
+| **Mailbox password** | Only in two-password mode (uncommon). | Once — same as TOTP. |
+
+A well-designed MCP server authenticates once, stores tokens, and refreshes them indefinitely. TOTP and CAPTCHA are **first-run problems**, not steady-state problems. This fundamentally shapes the design: the first authentication can afford to be interactive and slow.
+
+### TOTP — Straightforward in MCP
+
+TOTP is a 6-digit code from an authenticator app. The user knows the code. The challenge is routing the prompt through the agent environment to the human.
+
+**Strategy 1: MCP elicitation (recommended)**
+
+The MCP SDK supports [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/server/elicitation) — a mechanism for the server to ask the human user a question during tool execution. The server sends an `elicitation/create` request to the client, the client presents it to the user, and the response flows back.
+
+```
+Agent calls `login` tool
+  → MCP server begins SRP handshake
+  → API returns TwoFactor: 1
+  → MCP server sends elicitation: "Enter your TOTP code"
+  → MCP client prompts the human user
+  → Human enters 6-digit code
+  → MCP server completes auth with TOTP
+  → Tool returns success
+```
+
+This is the cleanest approach because it stays within the MCP protocol. The agent doesn't see the TOTP code (it goes directly between human and server). The 30-second TOTP window is tight but workable — elicitation should be fast since it's a simple text input.
+
+**Strategy 2: Two-phase tool flow**
+
+If the MCP client doesn't support elicitation, the server can use a two-tool pattern:
+
+1. `proton_login({ username, password })` → returns `{ status: 'totp_required' }`
+2. Agent sees the response, asks the human for the code
+3. `proton_login_totp({ code: '123456' })` → completes auth
+
+This has a timing problem: the agent must relay the request to the human, the human must open their authenticator, and the code must arrive within 30 seconds. In practice this works — TOTP codes are valid for the current and previous 30-second window (60 seconds effective), and the SRP session on the server side may have its own longer timeout.
+
+The risk here is that the agent sees the TOTP code in the conversation. It's a one-time code so the exposure is minimal, but it's a deviation from the elicitation approach where the code stays between human and server.
+
+**Strategy 3: Pre-authentication outside MCP**
+
+The MCP server could offer a CLI login command (`proton-bridge-mcp --login`) that handles authentication interactively before the agent ever connects. This is how Bridge works — you log in through the GUI once, then IMAP clients connect without knowing about SRP or TOTP.
+
+```bash
+$ proton-bridge-mcp --login
+Username: user@proton.me
+Password: ********
+TOTP code: 123456
+✓ Authenticated. Session stored in ~/.proton-mcp/session.enc
+$ # Now start the MCP server normally — agent connects, no auth needed
+```
+
+This is the simplest and most secure approach. The authentication flow is completely separate from the agent flow. No TOTP codes pass through the MCP protocol or the agent's context. The downside: the user must do a manual step before the agent can use the server.
+
+### CAPTCHA — The Hard Problem
+
+CAPTCHAs are fundamentally different from TOTP. A TOTP code is a number the user already has. A CAPTCHA is a visual challenge that requires rendering HTML/JavaScript in a browser context and human interaction with it.
+
+Proton's CAPTCHA flow works like this:
+
+1. API returns `HUMAN_VERIFICATION_REQUIRED` with methods: `["captcha"]`
+2. Client renders Proton's CAPTCHA page (an iframe/WebView pointing to a Proton URL)
+3. Human solves the challenge
+4. Client receives a verification token
+5. Client retries the original request with `X-PM-Human-Verification-Token` header
+
+The challenge requires a **browser environment**. It's not a simple image — it's an interactive web page with JavaScript. This means none of the pure-MCP strategies for TOTP work directly.
+
+**Strategy 1: Spawn a local browser (pragmatic)**
+
+```
+API returns HUMAN_VERIFICATION_REQUIRED
+  → MCP server starts a local HTTP server on a random port
+  → MCP server opens the user's browser to localhost:PORT/verify
+  → Page loads Proton's CAPTCHA in an iframe
+  → Human solves it
+  → Page posts token back to localhost:PORT/callback
+  → MCP server captures token, retries API call
+  → MCP server shuts down local HTTP server
+```
+
+This is essentially what Bridge does (with a WebView instead of a browser). The MCP server can notify the agent "waiting for human verification in browser" via the tool response, and the agent can relay this to the user.
+
+The user experience: a browser tab opens, they solve a CAPTCHA, the tab closes, and the agent continues. Awkward but workable.
+
+**Strategy 2: Elicitation with URL**
+
+If the MCP client supports elicitation, the server can send the CAPTCHA URL to the user:
+
+```
+MCP server sends elicitation:
+  "Proton requires human verification. Please open this URL in your 
+   browser, solve the challenge, and paste the token here:
+   https://verify.proton.me/captcha?token=xyz..."
+```
+
+This is fragile — the user would need to extract a token from the browser's network traffic or a callback URL, which is unreasonable for most users. Not recommended.
+
+**Strategy 3: Avoid CAPTCHAs entirely**
+
+The most practical strategy is to minimize CAPTCHA triggers:
+
+- **Authenticate through Bridge first**: If the user already has Bridge running and authenticated, the MCP server can piggyback on that session (Option C from the adaptation strategies). Bridge already solved any CAPTCHAs.
+- **Stable IP**: CAPTCHAs are triggered by suspicious network patterns. A stable home/office IP rarely triggers them.
+- **Pre-authenticate via CLI**: Run `--login` from the same network the server will run on. If a CAPTCHA appears during CLI login, spawn a browser then. Subsequent token refreshes don't trigger CAPTCHAs.
+- **Proton's alternative verification methods**: The API may offer email or SMS verification as alternatives to CAPTCHA. These can be handled via elicitation ("Enter the code sent to your email").
+
+**Strategy 4: Multimodal agent solves the CAPTCHA**
+
+A multimodal LLM with vision capabilities could theoretically render and solve a visual CAPTCHA. The MCP server could return the CAPTCHA as an image resource, and the agent could interpret and respond.
+
+This is a **terrible idea** for several reasons:
+- It's adversarial to Proton's anti-abuse system — they use CAPTCHAs to verify humans, and having an AI solve them defeats the purpose
+- Modern CAPTCHAs (reCAPTCHA v3, hCaptcha) use behavioral analysis, not just image recognition — they can't be solved by looking at an image
+- Proton could detect automated solving and permanently flag the account
+- It may violate Proton's Terms of Service
+
+Don't do this.
+
+### Recommended Design for MCP Server Auth
+
+```
+┌──────────────────────────────────────────────────────┐
+│                  First Run (interactive)               │
+│                                                        │
+│  $ proton-bridge-mcp --login                          │
+│    ├── SRP handshake                                  │
+│    ├── TOTP prompt (CLI stdin)                        │
+│    ├── CAPTCHA (spawn browser if triggered)           │
+│    ├── Mailbox password (CLI stdin, if two-pass mode) │
+│    ├── Decrypt keys, verify                           │
+│    └── Store session: ~/.proton-mcp/session.enc       │
+│         { AuthUID, RefreshToken, KeyPass }             │
+│                                                        │
+├──────────────────────────────────────────────────────┤
+│                  Steady State (headless)               │
+│                                                        │
+│  MCP server starts                                    │
+│    ├── Load session from disk                         │
+│    ├── Refresh token (no TOTP, no CAPTCHA)            │
+│    ├── Decrypt keys with stored KeyPass               │
+│    └── API ready — agent connects                     │
+│                                                        │
+│  If refresh token is revoked (rare):                  │
+│    ├── Tool calls return AUTH_REQUIRED error           │
+│    ├── Agent tells user: "run --login again"          │
+│    └── Back to First Run                              │
+│                                                        │
+├──────────────────────────────────────────────────────┤
+│                  Session Refresh (automatic)           │
+│                                                        │
+│  On 401 during tool execution:                        │
+│    ├── Refresh token automatically                    │
+│    ├── Retry original request                         │
+│    ├── Update stored RefreshToken                     │
+│    └── Transparent to agent                           │
+│                                                        │
+│  If refresh fails:                                    │
+│    └── Same as "refresh token revoked" above          │
+└──────────────────────────────────────────────────────┘
+```
+
+This design separates the interactive authentication (which needs human input for TOTP/CAPTCHA) from the headless operation (which only needs token refresh). The agent never encounters authentication challenges during normal use.
+
+The `--login` CLI command is analogous to Bridge's login GUI — it's a one-time setup step. Just as IMAP clients authenticate with BridgePass without knowing about SRP, the agent uses MCP tools without knowing about Proton authentication. The MCP server is the abstraction boundary.
+
+### Edge Case: Session Expires Mid-Conversation
+
+If the refresh token is revoked while the agent is mid-conversation (Proton account password changed, manual session revocation, etc.), the MCP server must fail gracefully:
+
+1. Tool call fails with a clear error: `AUTH_SESSION_EXPIRED`
+2. Agent sees the error and tells the user: "Your Proton session has expired. Please re-authenticate by running `proton-bridge-mcp --login`."
+3. After re-auth, the agent can resume
+
+This is preferable to attempting interactive re-authentication mid-conversation — the agent environment may not support elicitation, the TOTP code has a short window, and mixing authentication prompts into an email management conversation is confusing.
+
 ## Complete Auth Flow Comparison
 
 | Step | Web Client | Bridge | MCP Server (proposed) |


### PR DESCRIPTION
A 1700-line execution playbook for migrating proton-bridge-mcp from TypeScript to a new Go project (proton-mcp). Written for Claude as the executor in the new repo.

Recommends a new repo (not fork), lists what to retain (docs, conventions, design patterns, artwork), and provides 12 phases with per-phase verification criteria and release tags:

  Phase 0: Bootstrap
  Phase 1: Auth MVP (SRP login, encrypted vault)
  Phase 2: Server skeleton + distribution + v0.1.0
  Phase 3: Smoke tests (real + fake server modes)
  Phase 4: Read tools with attachment metadata (v0.2.0)
  Phase 5: Operation log + mark_read/unread + revert (v0.3.0)
  Phase 6: Folder/label CRUD (v0.4.0)
  Phase 7: Move + labels (v0.5.0)
  Phase 8: Body + attachment + search (v0.6.0)
  Phase 9: Cutover (no release)
  Phase 10: Cross-cutting improvements (v0.7.0)
  Phase 11: HTTP/HTTPS transports (v1.0.0)

Eliminates IMAP virtualization complexity by using go-proton-api directly. Drops two-password mode and CAPTCHA support (TOTP only). Drops drain_connections, renames verify_connectivity to verify_session.